### PR TITLE
Support for plain encoded binary in data pages

### DIFF
--- a/src/encoding/mod.rs
+++ b/src/encoding/mod.rs
@@ -5,6 +5,7 @@ pub mod delta_bitpacked;
 pub mod delta_byte_array;
 pub mod delta_length_byte_array;
 pub mod hybrid_rle;
+pub mod plain_byte_array;
 pub mod uleb128;
 pub mod zigzag_leb128;
 

--- a/src/encoding/plain_byte_array/decoder.rs
+++ b/src/encoding/plain_byte_array/decoder.rs
@@ -41,6 +41,6 @@ impl<'a> Iterator for Decoder<'a> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.remaining, None)
+        (self.remaining, Some(self.remaining))
     }
 }

--- a/src/encoding/plain_byte_array/decoder.rs
+++ b/src/encoding/plain_byte_array/decoder.rs
@@ -1,0 +1,37 @@
+use crate::encoding::get_length;
+
+/// Decodes according to [Plain strings](https://github.com/apache/parquet-format/blob/master/Encodings.md#plain-plain--0),
+/// prefixes, lengths and values
+/// # Implementation
+/// This struct does not allocate on the heap.
+#[derive(Debug)]
+pub struct Decoder<'a> {
+    values: &'a [u8],
+    index: usize,
+}
+
+impl<'a> Decoder<'a> {
+    pub fn new(values: &'a [u8]) -> Self {
+        Self { values, index: 0 }
+    }
+}
+
+impl<'a> Iterator for Decoder<'a> {
+    type Item = &'a [u8];
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let values = self.values;
+        let index = self.index;
+        if index + 4 < values.len() {
+            let next_len = get_length(values) as usize;
+            let next_index = index + 4 + next_len;
+
+            let result = Some(&values[index + 4..next_index]);
+            self.index = next_index;
+
+            result
+        } else {
+            None
+        }
+    }
+}

--- a/src/encoding/plain_byte_array/mod.rs
+++ b/src/encoding/plain_byte_array/mod.rs
@@ -1,0 +1,3 @@
+mod decoder;
+
+pub use decoder::Decoder;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,6 +172,7 @@ mod tests {
             2 => Array::Binary(string_values.to_vec()),
             3 => Array::Boolean(bool_values.to_vec()),
             4 => Array::Int64(i64_values.to_vec()),
+            6 => Array::Binary(string_values.to_vec()),
             _ => unreachable!(),
         }
     }
@@ -201,21 +202,33 @@ mod tests {
 
     // these values match the values in `integration`
     pub fn pyarrow_required(column: usize) -> Array {
-        let i64_values = &[
-            Some(0),
-            Some(1),
-            Some(2),
-            Some(3),
-            Some(4),
-            Some(5),
-            Some(6),
-            Some(7),
-            Some(8),
-            Some(9),
+        let i64_values = &[0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+        let f64_values = &[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
+        let string_values = &[
+            "Hello", "bbb", "aa", "", "bbb", "abc", "bbb", "bbb", "def", "aaa",
+        ];
+        let bool_values = &[
+            true, true, false, false, false, true, true, true, true, true,
         ];
 
         match column {
-            0 => Array::Int64(i64_values.to_vec()),
+            0 => Array::Int64(i64_values.iter().map(|i| Some(*i as i64)).collect()),
+            1 => Array::Float64(f64_values.iter().map(|f| Some(*f)).collect()),
+            2 => Array::Binary(
+                string_values
+                    .iter()
+                    .map(|s| Some(s.as_bytes().to_vec()))
+                    .collect(),
+            ),
+            3 => Array::Boolean(bool_values.iter().map(|b| Some(*b)).collect()),
+            4 => Array::Int64(i64_values.iter().map(|i| Some(*i as i64)).collect()),
+            5 => Array::Int32(i64_values.iter().map(|i| Some(*i as i32)).collect()),
+            6 => Array::Binary(
+                string_values
+                    .iter()
+                    .map(|s| Some(s.as_bytes().to_vec()))
+                    .collect(),
+            ),
             _ => unreachable!(),
         }
     }
@@ -223,6 +236,28 @@ mod tests {
     pub fn pyarrow_required_stats(column: usize) -> (Option<i64>, Value, Value) {
         match column {
             0 => (Some(0), Value::Int64(Some(0)), Value::Int64(Some(9))),
+            1 => (
+                Some(3),
+                Value::Float64(Some(0.0)),
+                Value::Float64(Some(9.0)),
+            ),
+            2 => (
+                Some(4),
+                Value::Binary(Some(b"".to_vec())),
+                Value::Binary(Some(b"def".to_vec())),
+            ),
+            3 => (
+                Some(4),
+                Value::Boolean(Some(false)),
+                Value::Boolean(Some(true)),
+            ),
+            4 => (Some(3), Value::Int64(Some(0)), Value::Int64(Some(9))),
+            5 => (Some(0), Value::Int32(Some(0)), Value::Int32(Some(9))),
+            6 => (
+                Some(4),
+                Value::Binary(Some(b"".to_vec())),
+                Value::Binary(Some(b"def".to_vec())),
+            ),
             _ => unreachable!(),
         }
     }

--- a/src/serialization/read/binary.rs
+++ b/src/serialization/read/binary.rs
@@ -71,7 +71,8 @@ fn read_plain_buffer(
 ) -> Vec<Option<Vec<u8>>> {
     let (values, def_levels) = consume_level(values, length, def_level_encoding);
 
-    let decoded_values = plain_byte_array::Decoder::new(values).map(|bytes| bytes.to_vec());
+    let decoded_values =
+        plain_byte_array::Decoder::new(values, length as usize).map(|bytes| bytes.to_vec());
 
     ValuesDef::new(
         decoded_values,

--- a/src/serialization/read/mod.rs
+++ b/src/serialization/read/mod.rs
@@ -118,7 +118,9 @@ pub fn page_to_array(page: CompressedPage, descriptor: &ColumnDescriptor) -> Res
 mod tests {
     use std::fs::File;
 
-    use crate::read::{get_page_iterator, read_metadata, PrimitiveStatistics, Statistics};
+    use crate::read::{
+        get_page_iterator, read_metadata, BinaryStatistics, PrimitiveStatistics, Statistics,
+    };
     use crate::tests::*;
     use crate::types::int96_to_i64;
 
@@ -277,6 +279,12 @@ mod tests {
                 assert_eq!(s.min_value, min);
                 assert_eq!(s.max_value, max);
             }
+            (Value::Binary(min), Value::Binary(max)) => {
+                let s = stats.as_any().downcast_ref::<BinaryStatistics>().unwrap();
+
+                assert_eq!(s.min_value, min);
+                assert_eq!(s.max_value, max);
+            }
 
             _ => todo!(),
         }
@@ -339,6 +347,28 @@ mod tests {
     #[test]
     fn pyarrow_v1_int32_optional() -> Result<()> {
         test_pyarrow_integration("basic", 0, 1, false)
+    }
+
+    #[test]
+    fn pyarrow_v1_dict_string_required() -> Result<()> {
+        test_pyarrow_integration("basic", 2, 1, true)
+    }
+
+    #[test]
+    #[ignore = "optional strings are not yet supported, see https://github.com/jorgecarleitao/parquet2/pull/7"]
+    fn pyarrow_v1_dict_string_optional() -> Result<()> {
+        test_pyarrow_integration("basic", 2, 1, false)
+    }
+
+    #[test]
+    fn pyarrow_v1_non_dict_string_required() -> Result<()> {
+        test_pyarrow_integration("basic", 6, 1, true)
+    }
+
+    #[test]
+    #[ignore = "optional non dictionary encoded strings seem to be written incorrectly by pyarrow, neither pyarrow itself nor rust parquet1 can read the generated file"]
+    fn pyarrow_v1_non_dict_string_optional() -> Result<()> {
+        test_pyarrow_integration("basic", 6, 1, false)
     }
 
     #[test]

--- a/src/serialization/read/mod.rs
+++ b/src/serialization/read/mod.rs
@@ -88,6 +88,9 @@ pub fn page_to_array(page: CompressedPage, descriptor: &ColumnDescriptor) -> Res
                 PhysicalType::Double => {
                     Ok(Array::Float64(primitive::page_to_vec(&page, descriptor)?))
                 }
+                PhysicalType::ByteArray => {
+                    Ok(Array::Binary(binary::page_to_vec(&page, descriptor)?))
+                }
                 _ => todo!(),
             },
         },


### PR DESCRIPTION
Support for plain encoded binary columns (used when all/most values in the column are distinct), split out from #7.

I now remember that this is the same logic as in `page_dict::binary::read_plain` so it might make sense to reuse the iterator there. The iterator should get a `size_hint` function so the correct capacity gets allocated.