### PR TITLE
Allowed writing metadata and created_by

### DIFF
--- a/src/serialization/write/mod.rs
+++ b/src/serialization/write/mod.rs
@@ -82,9 +82,11 @@ mod tests {
         let mut writer = Cursor::new(vec![]);
         write_file(
             &mut writer,
+            row_groups,
             schema,
             CompressionCodec::Uncompressed,
-            row_groups,
+            None,
+            None,
         )?;
 
         let data = writer.into_inner();

--- a/src/write/file.rs
+++ b/src/write/file.rs
@@ -8,6 +8,7 @@ use parquet_format::{CompressionCodec, FileMetaData};
 use thrift::protocol::TCompactOutputProtocol;
 use thrift::protocol::TOutputProtocol;
 
+pub use crate::metadata::KeyValue;
 use crate::{
     error::{ParquetError, Result},
     metadata::SchemaDescriptor,
@@ -52,9 +53,11 @@ pub fn write_file<
     E,   // external error any of the iterators may emit
 >(
     writer: &mut W,
+    row_groups: III,
     schema: SchemaDescriptor,
     codec: CompressionCodec,
-    row_groups: III,
+    created_by: Option<String>,
+    key_value_metadata: Option<Vec<KeyValue>>,
 ) -> Result<()>
 where
     W: Write + Seek,
@@ -84,8 +87,8 @@ where
         schema.into_thrift()?,
         num_rows,
         row_groups,
-        None,
-        None,
+        key_value_metadata,
+        created_by,
         None,
     );
 

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -38,7 +38,7 @@ mod tests {
         let schema = SchemaDescriptor::try_from_message("message schema { OPTIONAL INT32 col; }")?;
 
         let mut writer = Cursor::new(vec![]);
-        write_file(&mut writer, schema, compression, row_groups)?;
+        write_file(&mut writer, row_groups, schema, compression, None, None)?;
 
         let data = writer.into_inner();
         let mut reader = Cursor::new(data);


### PR DESCRIPTION
This exposes these two to `write_file`, which are needed when people want to write metadata to the file.