### PR TITLE
Improved API to re-use page buffers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ bench = false
 parquet-format = "~2.6.1"
 thrift = "0.13"
 bitpacking = { version = "0.8.2", features = ["bitpacker1x"] }
+streaming-iterator = "0.1.5"
 
 snap = { version = "^1.0", optional = true }
 brotli = { version = "^3.3", optional = true }

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ use `PARQUET2_IGNORE_PYARROW_TESTS= cargo test`. To run then, you will need to r
 ```bash
 python3 -m venv venv
 venv/bin/pip install pip --upgrade
-venv/bin/pip install pyarrow==3
+venv/bin/pip install pyarrow==4
 venv/bin/python integration/write_pyarrow.py
 ```
 

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -29,7 +29,7 @@ pub trait Codec: std::fmt::Debug {
 
     /// Decompresses data stored in slice `input_buf` and writes output to `output_buf`.
     /// Returns the total number of bytes written.
-    fn decompress(&mut self, input_buf: &[u8], output_buf: &mut Vec<u8>) -> Result<usize>;
+    fn decompress(&mut self, input_buf: &[u8], output_buf: &mut [u8]) -> Result<()>;
 }
 
 /// Given the compression type `codec`, returns a codec used to compress and decompress
@@ -81,12 +81,13 @@ mod snappy_codec {
     }
 
     impl Codec for SnappyCodec {
-        fn decompress(&mut self, input_buf: &[u8], output_buf: &mut Vec<u8>) -> Result<usize> {
+        fn decompress(&mut self, input_buf: &[u8], output_buf: &mut [u8]) -> Result<()> {
             let len = decompress_len(input_buf)?;
-            output_buf.resize(len, 0);
+            assert!(len <= output_buf.len());
             self.decoder
                 .decompress(input_buf, output_buf)
                 .map_err(|e| e.into())
+                .map(|_| ())
         }
 
         fn compress(&mut self, input_buf: &[u8], output_buf: &mut Vec<u8>) -> Result<()> {
@@ -126,9 +127,9 @@ mod gzip_codec {
     }
 
     impl Codec for GZipCodec {
-        fn decompress(&mut self, input_buf: &[u8], output_buf: &mut Vec<u8>) -> Result<usize> {
+        fn decompress(&mut self, input_buf: &[u8], output_buf: &mut [u8]) -> Result<()> {
             let mut decoder = read::GzDecoder::new(input_buf);
-            decoder.read_to_end(output_buf).map_err(|e| e.into())
+            decoder.read_exact(output_buf).map_err(|e| e.into())
         }
 
         fn compress(&mut self, input_buf: &[u8], output_buf: &mut Vec<u8>) -> Result<()> {
@@ -165,9 +166,9 @@ mod brotli_codec {
     }
 
     impl Codec for BrotliCodec {
-        fn decompress(&mut self, input_buf: &[u8], output_buf: &mut Vec<u8>) -> Result<usize> {
+        fn decompress(&mut self, input_buf: &[u8], output_buf: &mut [u8]) -> Result<()> {
             brotli::Decompressor::new(input_buf, BROTLI_DEFAULT_BUFFER_SIZE)
-                .read_to_end(output_buf)
+                .read_exact(output_buf)
                 .map_err(|e| e.into())
         }
 
@@ -207,21 +208,9 @@ mod lz4_codec {
     }
 
     impl Codec for Lz4Codec {
-        fn decompress(&mut self, input_buf: &[u8], output_buf: &mut Vec<u8>) -> Result<usize> {
+        fn decompress(&mut self, input_buf: &[u8], output_buf: &mut [u8]) -> Result<()> {
             let mut decoder = lz4::Decoder::new(input_buf)?;
-            let mut total_len = 0;
-            loop {
-                let previous_len = output_buf.len();
-                output_buf.extend(std::iter::repeat(0).take(LZ4_BUFFER_SIZE));
-                let len =
-                    decoder.read(&mut output_buf[previous_len..previous_len + LZ4_BUFFER_SIZE])?;
-                total_len += len;
-                if len < LZ4_BUFFER_SIZE {
-                    output_buf.truncate(total_len);
-                    break;
-                }
-            }
-            Ok(total_len)
+            decoder.read_exact(output_buf).map_err(|e| e.into())
         }
 
         fn compress(&mut self, input_buf: &[u8], output_buf: &mut Vec<u8>) -> Result<()> {
@@ -244,7 +233,8 @@ pub use lz4_codec::*;
 
 #[cfg(feature = "zstd")]
 mod zstd_codec {
-    use std::io::{self, Write};
+    use std::io::Read;
+    use std::io::Write;
 
     use crate::compression::Codec;
     use crate::error::Result;
@@ -264,12 +254,9 @@ mod zstd_codec {
     const ZSTD_COMPRESSION_LEVEL: i32 = 1;
 
     impl Codec for ZstdCodec {
-        fn decompress(&mut self, input_buf: &[u8], output_buf: &mut Vec<u8>) -> Result<usize> {
+        fn decompress(&mut self, input_buf: &[u8], output_buf: &mut [u8]) -> Result<()> {
             let mut decoder = zstd::Decoder::new(input_buf)?;
-            match io::copy(&mut decoder, output_buf) {
-                Ok(n) => Ok(n as usize),
-                Err(e) => Err(e.into()),
-            }
+            decoder.read_exact(output_buf).map_err(|e| e.into())
         }
 
         fn compress(&mut self, input_buf: &[u8], output_buf: &mut Vec<u8>) -> Result<()> {
@@ -295,16 +282,13 @@ mod tests {
 
         // Compress with c1
         let mut compressed = Vec::new();
-        let mut decompressed = Vec::new();
         c1.compress(data, &mut compressed)
             .expect("Error when compressing");
 
         // Decompress with c2
-        let mut decompressed_size = c2
-            .decompress(compressed.as_slice(), &mut decompressed)
+        let mut decompressed = vec![0; data.len()];
+        c2.decompress(compressed.as_slice(), &mut decompressed)
             .expect("Error when decompressing");
-        assert_eq!(data.len(), decompressed_size);
-        decompressed.truncate(decompressed_size);
         assert_eq!(data, decompressed.as_slice());
 
         compressed.clear();
@@ -314,11 +298,8 @@ mod tests {
             .expect("Error when compressing");
 
         // Decompress with c1
-        decompressed_size = c1
-            .decompress(compressed.as_slice(), &mut decompressed)
+        c1.decompress(compressed.as_slice(), &mut decompressed)
             .expect("Error when decompressing");
-        assert_eq!(data.len(), decompressed_size);
-        decompressed.truncate(decompressed_size);
         assert_eq!(data, decompressed.as_slice());
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,11 +1,13 @@
-#[derive(Debug)]
+use std::sync::Arc;
+
+#[derive(Debug, Clone)]
 pub enum ParquetError {
     /// General Parquet error.
     General(String),
     /// When the parquet file is known to be out of spec.
     OutOfSpec(String),
     // An error originating from a consumer or dependency
-    External(String, Box<dyn std::error::Error + Send + Sync>),
+    External(String, Arc<dyn std::error::Error + Send + Sync>),
 }
 
 impl std::error::Error for ParquetError {}
@@ -29,7 +31,7 @@ impl std::fmt::Display for ParquetError {
 impl ParquetError {
     /// Wraps an external error in an `ParquetError`.
     pub fn from_external_error(error: impl std::error::Error + Send + Sync + 'static) -> Self {
-        Self::External("".to_string(), Box::new(error))
+        Self::External("".to_string(), Arc::new(error))
     }
 }
 

--- a/src/metadata/column_chunk_metadata.rs
+++ b/src/metadata/column_chunk_metadata.rs
@@ -2,6 +2,7 @@ use parquet_format::{ColumnChunk, ColumnMetaData, Encoding, Statistics};
 
 use super::column_descriptor::ColumnDescriptor;
 use crate::error::Result;
+use crate::schema::types::{ParquetType, PhysicalType};
 use crate::{compression::CompressionCodec, schema::types::Type};
 
 /// Metadata for a column chunk.
@@ -41,6 +42,15 @@ impl ColumnChunkMetaData {
     /// of the pages.
     pub fn descriptor(&self) -> &ColumnDescriptor {
         &self.column_descr
+    }
+
+    /// The [`ColumnDescriptor`] for this column. This descriptor contains the physical and logical type
+    /// of the pages.
+    pub fn physical_type(&self) -> PhysicalType {
+        match self.descriptor().type_() {
+            ParquetType::PrimitiveType { physical_type, .. } => *physical_type,
+            _ => unreachable!(),
+        }
     }
 
     /// Descriptor for this column.

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -1,10 +1,14 @@
 mod compression;
-pub use compression::decompress_page;
 mod metadata;
 mod page;
 mod page_dict;
 mod page_iterator;
 mod statistics;
+
+pub use streaming_iterator;
+pub use streaming_iterator::StreamingIterator;
+
+pub use compression::{decompress, Decompressor};
 
 pub use metadata::read_metadata;
 
@@ -13,7 +17,7 @@ use std::io::{Read, Seek, SeekFrom};
 use crate::metadata::RowGroupMetaData;
 use crate::{error::Result, metadata::FileMetaData};
 
-pub use page::{CompressedPage, Page, PageV1, PageV2};
+pub use page::{CompressedPage, Page, PageHeader};
 pub use page_dict::{BinaryPageDict, FixedLenByteArrayPageDict, PageDict, PrimitivePageDict};
 pub use page_iterator::PageIterator;
 pub use statistics::*;
@@ -35,21 +39,23 @@ pub fn filter_row_groups(
     metadata
 }
 
-pub fn get_page_iterator<'b, RR: Read + Seek>(
+pub fn get_page_iterator<'a, RR: Read + Seek>(
     metadata: &FileMetaData,
     row_group: usize,
     column: usize,
-    reader: &'b mut RR,
-) -> Result<PageIterator<'b, RR>> {
+    reader: &'a mut RR,
+    buffer: Vec<u8>,
+) -> Result<PageIterator<'a, RR>> {
     let column_metadata = metadata.row_groups[row_group].column(column);
     let (col_start, _) = column_metadata.byte_range();
     reader.seek(SeekFrom::Start(col_start))?;
-    PageIterator::try_new(
+    Ok(PageIterator::new(
         reader,
         column_metadata.num_values(),
         *column_metadata.compression(),
-        column_metadata.descriptor().clone(),
-    )
+        column_metadata.physical_type(),
+        buffer,
+    ))
 }
 
 #[cfg(test)]
@@ -70,14 +76,60 @@ mod tests {
 
         let row_group = 0;
         let column = 0;
-        let mut iter = get_page_iterator(&metadata, row_group, column, &mut file)?;
+        let buffer = vec![];
+        let mut iter = get_page_iterator(&metadata, row_group, column, &mut file, buffer)?;
 
-        let a = iter.next().unwrap().unwrap();
-        if let CompressedPage::V1(page) = &a {
-            assert_eq!(page.header.num_values, 8)
-        } else {
-            panic!("Page not a dict");
-        }
+        let page = iter.next().unwrap().unwrap();
+        assert_eq!(page.num_values(), 8);
+        Ok(())
+    }
+
+    #[test]
+    fn reuse_buffer() -> Result<()> {
+        let mut testdata = get_path();
+        testdata.push("alltypes_plain.parquet");
+        let mut file = File::open(testdata).unwrap();
+
+        let metadata = read_metadata(&mut file)?;
+
+        let row_group = 0;
+        let column = 0;
+        let buffer = vec![0];
+        let mut iterator = get_page_iterator(&metadata, row_group, column, &mut file, buffer)?;
+
+        let page = iterator.next().unwrap().unwrap();
+        iterator.reuse_buffer(page.buffer);
+
+        assert!(iterator.next().is_none());
+        assert!(!iterator.buffer.is_empty());
+
+        Ok(())
+    }
+
+    #[test]
+    fn reuse_buffer_decompress() -> Result<()> {
+        let mut testdata = get_path();
+        testdata.push("alltypes_plain.parquet");
+        let mut file = File::open(testdata).unwrap();
+
+        let metadata = read_metadata(&mut file)?;
+
+        let row_group = 0;
+        let column = 0;
+        let buffer = vec![1];
+        let iterator = get_page_iterator(&metadata, row_group, column, &mut file, buffer)?;
+
+        let buffer = vec![];
+        let mut iterator = Decompressor::new(iterator, buffer);
+
+        iterator.next().unwrap().as_ref().unwrap();
+
+        assert!(iterator.next().is_none());
+        let (a, b) = iterator.into_buffers();
+
+        assert_eq!(a.len(), 11);
+        assert_eq!(b.len(), 0); // the decompressed buffer is never used because it is always swapped with the other buffer.
+
         Ok(())
     }
 }

--- a/src/read/page.rs
+++ b/src/read/page.rs
@@ -1,76 +1,130 @@
 use std::sync::Arc;
 
+use parquet_format::Encoding;
 use parquet_format::{CompressionCodec, DataPageHeader, DataPageHeaderV2};
 
 use super::page_dict::PageDict;
 use super::statistics::Statistics;
 
-#[derive(Debug)]
-pub struct PageV1 {
-    pub buffer: Vec<u8>,
-    pub header: DataPageHeader,
-    pub compression: CompressionCodec,
-    pub uncompressed_page_size: usize,
-    pub dictionary_page: Option<Arc<dyn PageDict>>,
-    pub statistics: Option<Arc<dyn Statistics>>,
-}
-
-#[derive(Debug)]
-pub struct PageV2 {
-    pub buffer: Vec<u8>,
-    pub header: DataPageHeaderV2,
-    pub compression: CompressionCodec,
-    pub uncompressed_page_size: usize,
-    pub dictionary_page: Option<Arc<dyn PageDict>>,
-    pub statistics: Option<Arc<dyn Statistics>>,
-}
-
 /// A [`CompressedPage`] is compressed, encoded representation of a Parquet page. It holds actual data
 /// and thus cloning it is expensive. Favor passing this enum by value, as it deallocates it
 /// as soon as it is not needed, thereby reducing memory usage.
 #[derive(Debug)]
-pub enum CompressedPage {
-    V1(PageV1),
-    V2(PageV2),
+pub struct CompressedPage {
+    pub(crate) header: PageHeader,
+    pub(crate) buffer: Vec<u8>,
+    compression: CompressionCodec,
+    uncompressed_page_size: usize,
+    pub(crate) dictionary_page: Option<Arc<dyn PageDict>>,
+    pub(crate) statistics: Option<Arc<dyn Statistics>>,
 }
 
 impl CompressedPage {
-    pub fn compressed_size(&self) -> usize {
-        match self {
-            Self::V1(page) => page.buffer.len(),
-            Self::V2(page) => page.buffer.len(),
+    pub fn new(
+        header: PageHeader,
+        buffer: Vec<u8>,
+        compression: CompressionCodec,
+        uncompressed_page_size: usize,
+        dictionary_page: Option<Arc<dyn PageDict>>,
+        statistics: Option<Arc<dyn Statistics>>,
+    ) -> Self {
+        Self {
+            header,
+            buffer,
+            compression,
+            uncompressed_page_size,
+            dictionary_page,
+            statistics,
         }
+    }
+
+    pub fn header(&self) -> &PageHeader {
+        &self.header
     }
 
     pub fn uncompressed_size(&self) -> usize {
-        match self {
-            Self::V1(page) => page.uncompressed_page_size,
-            Self::V2(page) => page.uncompressed_page_size,
-        }
+        self.uncompressed_page_size
     }
 
     pub fn statistics(&self) -> Option<&Arc<dyn Statistics>> {
-        match self {
-            Self::V1(page) => page.statistics.as_ref(),
-            Self::V2(page) => page.statistics.as_ref(),
+        self.statistics.as_ref()
+    }
+
+    pub fn compressed_size(&self) -> usize {
+        self.buffer.len()
+    }
+
+    pub fn compression(&self) -> CompressionCodec {
+        self.compression
+    }
+
+    pub fn num_values(&self) -> usize {
+        match &self.header {
+            PageHeader::V1(d) => d.num_values as usize,
+            PageHeader::V2(d) => d.num_values as usize,
         }
     }
+}
+
+#[derive(Debug, Clone)]
+pub enum PageHeader {
+    V1(DataPageHeader),
+    V2(DataPageHeaderV2),
 }
 
 /// A [`Page`] is an uncompressed, encoded representation of a Parquet page. It holds actual data
 /// and thus cloning it is expensive. Favor passing this enum by value, as it deallocates it
 /// as soon as it is not needed, thereby reducing memory usage.
-#[derive(Debug)]
-pub enum Page {
-    V1(PageV1),
-    V2(PageV2),
+#[derive(Debug, Clone)]
+pub struct Page {
+    header: PageHeader,
+    pub(super) buffer: Vec<u8>,
+    dictionary_page: Option<Arc<dyn PageDict>>,
+    statistics: Option<Arc<dyn Statistics>>,
 }
 
 impl Page {
-    pub fn dictionary_page(&self) -> Option<&dyn PageDict> {
-        match self {
-            Self::V1(page) => page.dictionary_page.as_ref().map(|x| x.as_ref()),
-            Self::V2(page) => page.dictionary_page.as_ref().map(|x| x.as_ref()),
+    pub fn new(
+        header: PageHeader,
+        buffer: Vec<u8>,
+        dictionary_page: Option<Arc<dyn PageDict>>,
+        statistics: Option<Arc<dyn Statistics>>,
+    ) -> Self {
+        Self {
+            header,
+            buffer,
+            dictionary_page,
+            statistics,
+        }
+    }
+
+    pub fn statistics(&self) -> Option<&Arc<dyn Statistics>> {
+        self.statistics.as_ref()
+    }
+
+    pub fn header(&self) -> &PageHeader {
+        &self.header
+    }
+
+    pub fn dictionary_page(&self) -> Option<&Arc<dyn PageDict>> {
+        self.dictionary_page.as_ref()
+    }
+
+    pub fn buffer(&self) -> &[u8] {
+        &self.buffer
+    }
+
+    pub fn num_values(&self) -> usize {
+        match &self.header {
+            PageHeader::V1(d) => d.num_values as usize,
+            PageHeader::V2(d) => d.num_values as usize,
+        }
+    }
+
+    pub fn encoding(&self) -> Encoding {
+        match &self.header {
+            PageHeader::V1(d) => d.encoding,
+            PageHeader::V2(d) => d.encoding,
         }
     }
 }

--- a/src/read/page_iterator.rs
+++ b/src/read/page_iterator.rs
@@ -1,12 +1,13 @@
 use std::{io::Read, sync::Arc};
 
-use parquet_format::{CompressionCodec, PageHeader, PageType};
+use parquet_format::{CompressionCodec, PageHeader as ParquetPageHeader, PageType};
 use thrift::protocol::TCompactInputProtocol;
 
-use crate::schema::types::ParquetType;
-use crate::{error::Result, metadata::ColumnDescriptor};
+use crate::error::Result;
+use crate::schema::types::PhysicalType;
 
-use super::page::{CompressedPage, PageV1, PageV2};
+use super::page::CompressedPage;
+use super::page::PageHeader;
 use super::page_dict::{read_page_dict, PageDict};
 use super::statistics::deserialize_statistics;
 
@@ -28,36 +29,40 @@ pub struct PageIterator<'a, R: Read> {
     // Arc: it will be shared between multiple pages and pages should be Send + Sync.
     current_dictionary: Option<Arc<dyn PageDict>>,
 
-    //
-    descriptor: ColumnDescriptor,
+    physical_type: PhysicalType,
+
+    // The currently allocated buffer.
+    pub(crate) buffer: Vec<u8>,
 }
 
 impl<'a, R: Read> PageIterator<'a, R> {
-    pub fn try_new(
+    pub fn new(
         reader: &'a mut R,
         total_num_values: i64,
         compression: CompressionCodec,
-        descriptor: ColumnDescriptor,
-    ) -> Result<Self> {
-        Ok(Self {
+        physical_type: PhysicalType,
+        buffer: Vec<u8>,
+    ) -> Self {
+        Self {
             reader,
             total_num_values,
             compression,
             seen_num_values: 0,
             current_dictionary: None,
-            descriptor,
-        })
+            physical_type,
+            buffer,
+        }
     }
 
     /// Reads Page header from Thrift.
-    fn read_page_header(&mut self) -> Result<PageHeader> {
+    fn read_page_header(&mut self) -> Result<ParquetPageHeader> {
         let mut prot = TCompactInputProtocol::new(&mut self.reader);
-        let page_header = PageHeader::read_from_in_protocol(&mut prot)?;
+        let page_header = ParquetPageHeader::read_from_in_protocol(&mut prot)?;
         Ok(page_header)
     }
 
-    pub fn descriptor(&self) -> &ColumnDescriptor {
-        &self.descriptor
+    pub fn reuse_buffer(&mut self, buffer: Vec<u8>) {
+        self.buffer = buffer;
     }
 }
 
@@ -65,86 +70,107 @@ impl<'a, R: Read> Iterator for PageIterator<'a, R> {
     type Item = Result<CompressedPage>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        next_page(self).transpose()
+        let mut buffer = std::mem::take(&mut self.buffer);
+        let result = next_page(self, &mut buffer).transpose();
+        if result.is_none() {
+            // if no page, we take back the buffer
+            self.buffer = std::mem::take(&mut buffer);
+        }
+        result
     }
 }
 
 /// This function is lightweight and executes a minimal amount of work so that it is IO bounded.
 // Any un-necessary CPU-intensive tasks SHOULD be executed on individual pages.
-fn next_page<R: Read>(reader: &mut PageIterator<R>) -> Result<Option<CompressedPage>> {
-    while reader.seen_num_values < reader.total_num_values {
-        let page_header = reader.read_page_header()?;
+fn next_page<R: Read>(
+    reader: &mut PageIterator<R>,
+    buffer: &mut Vec<u8>,
+) -> Result<Option<CompressedPage>> {
+    let total_values = reader.total_num_values;
+    let mut seen_values = reader.seen_num_values;
+    if seen_values >= total_values {
+        return Ok(None);
+    };
 
-        let mut buffer = vec![0; page_header.compressed_page_size as usize];
-        reader.reader.read_exact(&mut buffer)?;
-
-        let physical_type = match reader.descriptor.type_() {
-            ParquetType::PrimitiveType { physical_type, .. } => physical_type,
-            _ => unreachable!(),
-        };
-
-        let result = match page_header.type_ {
-            PageType::DictionaryPage => {
-                let dict_header = page_header.dictionary_page_header.as_ref().unwrap();
-                let is_sorted = dict_header.is_sorted.unwrap_or(false);
-
-                let page = read_page_dict(
-                    buffer,
-                    dict_header.num_values as u32,
-                    (
-                        reader.compression,
-                        page_header.uncompressed_page_size as usize,
-                    ),
-                    is_sorted,
-                    *physical_type,
-                )?;
-
-                reader.current_dictionary = Some(page);
-                continue;
-            }
-            PageType::DataPage => {
-                let header = page_header.data_page_header.unwrap();
-                reader.seen_num_values += header.num_values as i64;
-
-                let statistics = header
-                    .statistics
-                    .as_ref()
-                    .map(|s| deserialize_statistics(s, physical_type))
-                    .transpose()?;
-
-                CompressedPage::V1(PageV1 {
-                    buffer,
-                    header,
-                    compression: reader.compression,
-                    uncompressed_page_size: page_header.uncompressed_page_size as usize,
-                    dictionary_page: reader.current_dictionary.clone(),
-                    statistics,
-                })
-            }
-            PageType::DataPageV2 => {
-                let header = page_header.data_page_header_v2.unwrap();
-                reader.seen_num_values += header.num_values as i64;
-
-                let statistics = header
-                    .statistics
-                    .as_ref()
-                    .map(|s| deserialize_statistics(s, physical_type))
-                    .transpose()?;
-
-                CompressedPage::V2(PageV2 {
-                    buffer,
-                    header,
-                    compression: reader.compression,
-                    uncompressed_page_size: page_header.uncompressed_page_size as usize,
-                    dictionary_page: reader.current_dictionary.clone(),
-                    statistics,
-                })
-            }
-            PageType::IndexPage => {
-                continue;
-            }
-        };
-        return Ok(Some(result));
+    while seen_values < total_values {
+        let page = build_page(reader, buffer)?;
+        seen_values = reader.seen_num_values;
+        if let Some(page) = page {
+            return Ok(Some(page));
+        }
     }
     Ok(None)
+}
+
+fn build_page<R: Read>(
+    reader: &mut PageIterator<R>,
+    buffer: &mut Vec<u8>,
+) -> Result<Option<CompressedPage>> {
+    let page_header = reader.read_page_header()?;
+
+    let read_size = page_header.compressed_page_size as usize;
+    if read_size > 0 {
+        buffer.resize(read_size, 0);
+        reader.reader.read_exact(buffer)?;
+    }
+
+    match page_header.type_ {
+        PageType::DictionaryPage => {
+            let dict_header = page_header.dictionary_page_header.as_ref().unwrap();
+            let is_sorted = dict_header.is_sorted.unwrap_or(false);
+
+            let page = read_page_dict(
+                &buffer,
+                dict_header.num_values as u32,
+                (
+                    reader.compression,
+                    page_header.uncompressed_page_size as usize,
+                ),
+                is_sorted,
+                reader.physical_type,
+            )?;
+
+            reader.current_dictionary = Some(page);
+            Ok(None)
+        }
+        PageType::DataPage => {
+            let header = page_header.data_page_header.unwrap();
+            reader.seen_num_values += header.num_values as i64;
+
+            let statistics = header
+                .statistics
+                .as_ref()
+                .map(|s| deserialize_statistics(s, &reader.physical_type))
+                .transpose()?;
+
+            Ok(Some(CompressedPage::new(
+                PageHeader::V1(header),
+                std::mem::take(buffer),
+                reader.compression,
+                page_header.uncompressed_page_size as usize,
+                reader.current_dictionary.clone(),
+                statistics,
+            )))
+        }
+        PageType::DataPageV2 => {
+            let header = page_header.data_page_header_v2.unwrap();
+            reader.seen_num_values += header.num_values as i64;
+
+            let statistics = header
+                .statistics
+                .as_ref()
+                .map(|s| deserialize_statistics(s, &reader.physical_type))
+                .transpose()?;
+
+            Ok(Some(CompressedPage::new(
+                PageHeader::V2(header),
+                std::mem::take(buffer),
+                reader.compression,
+                page_header.uncompressed_page_size as usize,
+                reader.current_dictionary.clone(),
+                statistics,
+            )))
+        }
+        PageType::IndexPage => Ok(None),
+    }
 }

--- a/src/serialization/read/boolean.rs
+++ b/src/serialization/read/boolean.rs
@@ -3,6 +3,7 @@ use parquet_format::Encoding;
 use crate::error::Result;
 use crate::metadata::ColumnDescriptor;
 use crate::read::Page;
+use crate::read::PageHeader;
 
 const BIT_MASK: [u8; 8] = [1, 2, 4, 8, 16, 32, 64, 128];
 
@@ -27,16 +28,16 @@ fn read_bitmap(values: &[u8], length: usize) -> Vec<Option<bool>> {
 }
 
 pub fn page_to_vec(page: &Page, _: &ColumnDescriptor) -> Result<Vec<Option<bool>>> {
-    match page {
-        Page::V1(page) => match page.header.encoding {
+    match page.header() {
+        PageHeader::V1(_) => match page.encoding() {
             Encoding::Plain | Encoding::PlainDictionary => {
-                Ok(read_bitmap(&page.buffer, page.header.num_values as usize))
+                Ok(read_bitmap(page.buffer(), page.num_values()))
             }
             _ => todo!(),
         },
-        Page::V2(page) => match page.header.encoding {
+        PageHeader::V2(_) => match page.encoding() {
             Encoding::Plain | Encoding::PlainDictionary => {
-                Ok(read_bitmap(&page.buffer, page.header.num_values as usize))
+                Ok(read_bitmap(page.buffer(), page.num_values()))
             }
             _ => todo!(),
         },

--- a/src/serialization/read/record_batch.rs
+++ b/src/serialization/read/record_batch.rs
@@ -1,0 +1,69 @@
+use std::io::{Read, Seek};
+
+use streaming_iterator::StreamingIterator;
+
+use super::{page_to_array, Array};
+use crate::read::{get_page_iterator, read_metadata, Decompressor};
+use crate::{error::Result, metadata::FileMetaData};
+
+/// Single threaded iterator of `RecordBatch`.
+pub struct RecordReader<R: Read + Seek> {
+    reader: R,
+    buffer: Vec<u8>,
+    decompress_buffer: Vec<u8>,
+    metadata: FileMetaData,
+    current_group: usize,
+}
+
+impl<R: Read + Seek> RecordReader<R> {
+    pub fn try_new(mut reader: R) -> Result<Self> {
+        let metadata = read_metadata(&mut reader)?;
+        Ok(Self {
+            reader,
+            metadata,
+            current_group: 0,
+            buffer: vec![],
+            decompress_buffer: vec![],
+        })
+    }
+}
+
+impl<R: Read + Seek> Iterator for RecordReader<R> {
+    type Item = Result<Vec<Vec<Array>>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.current_group == self.metadata.row_groups.len() {
+            return None;
+        };
+        let row_group = self.current_group;
+        let metadata = self.metadata.clone();
+        let group = &metadata.row_groups[row_group];
+
+        let b1 = std::mem::take(&mut self.buffer);
+        let b2 = std::mem::take(&mut self.decompress_buffer);
+
+        let a = group.columns().iter().enumerate().try_fold(
+            (b1, b2, vec![]),
+            |(b1, b2, mut columns), (column, column_meta)| {
+                let pages = get_page_iterator(&metadata, row_group, column, &mut self.reader, b1)?;
+                let mut pages = Decompressor::new(pages, b2);
+
+                let mut arrays = vec![];
+                while let Some(page) = pages.next() {
+                    let array = page_to_array(page.as_ref().unwrap(), column_meta.descriptor())?;
+                    arrays.push(array);
+                }
+                columns.push(arrays);
+                let (b1, b2) = pages.into_buffers();
+                Result::Ok((b1, b2, columns))
+            },
+        );
+
+        self.current_group += 1;
+        Some(a.and_then(|(b1, b2, columns)| {
+            self.buffer = b1;
+            self.decompress_buffer = b2;
+            Ok(columns)
+        }))
+    }
+}

--- a/src/serialization/write/mod.rs
+++ b/src/serialization/write/mod.rs
@@ -23,39 +23,17 @@ pub fn array_to_page(array: &Array) -> Result<CompressedPage> {
 mod tests {
     use std::io::{Cursor, Read, Seek};
 
-    use crate::read::{get_page_iterator, read_metadata};
     use crate::tests::alltypes_plain;
     use crate::write::write_file;
 
     use crate::metadata::SchemaDescriptor;
-    use crate::serialization::read::page_to_array;
 
     use super::*;
-    use crate::{error::Result, metadata::ColumnDescriptor, read::CompressedPage};
-
-    fn get_pages<R: Read + Seek>(
-        reader: &mut R,
-        row_group: usize,
-        column: usize,
-    ) -> Result<(ColumnDescriptor, Vec<CompressedPage>)> {
-        let metadata = read_metadata(reader)?;
-        let descriptor = metadata.row_groups[row_group]
-            .column(column)
-            .descriptor()
-            .clone();
-        Ok((
-            descriptor,
-            get_page_iterator(&metadata, row_group, column, reader)?.collect::<Result<Vec<_>>>()?,
-        ))
-    }
+    use crate::error::Result;
 
     fn read_column<R: Read + Seek>(reader: &mut R) -> Result<Array> {
-        let (descriptor, mut pages) = get_pages(reader, 0, 0)?;
-        assert_eq!(pages.len(), 1);
-
-        let page = pages.pop().unwrap();
-
-        page_to_array(page, &descriptor)
+        let (a, _) = super::super::read::tests::read_column(reader, 0, 0)?;
+        Ok(a)
     }
 
     fn test_column(column: usize) -> Result<()> {

--- a/src/serialization/write/primitive.rs
+++ b/src/serialization/write/primitive.rs
@@ -1,6 +1,7 @@
 use parquet_format::{CompressionCodec, DataPageHeader, Encoding};
 
-use crate::{compression::create_codec, encoding::hybrid_rle::encode, error::Result, read::PageV1};
+use crate::read::PageHeader;
+use crate::{compression::create_codec, encoding::hybrid_rle::encode, error::Result};
 use crate::{read::CompressedPage, types::NativeType};
 
 fn unzip_option<T: NativeType>(array: &[Option<T>]) -> Result<(Vec<u8>, Vec<u8>)> {
@@ -63,12 +64,12 @@ pub fn array_to_page_v1<T: NativeType>(
         statistics: None,
     };
 
-    Ok(CompressedPage::V1(PageV1 {
+    Ok(CompressedPage::new(
+        PageHeader::V1(header),
         buffer,
-        header,
         compression,
         uncompressed_page_size,
-        dictionary_page: None,
-        statistics: None,
-    }))
+        None,
+        None,
+    ))
 }

--- a/src/write/compression.rs
+++ b/src/write/compression.rs
@@ -1,7 +1,7 @@
 use crate::error::Result;
 use crate::{
     compression::{create_codec, Codec},
-    read::{CompressedPage, Page, PageV1, PageV2},
+    read::{CompressedPage, Page, PageHeader},
 };
 
 fn compress_(buffer: &[u8], decompressor: &mut dyn Codec) -> Result<Vec<u8>> {

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -1,5 +1,5 @@
 mod column_chunk;
-mod compression;
+//mod compression;
 mod file;
 mod page;
 mod row_group;


### PR DESCRIPTION
This allows re-using the page buffers, thereby reducing alloc and free when reading multiple pages.