### PR TITLE
Allow writing a file from a stream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ thrift = "0.13"
 bitpacking = { version = "0.8.2", features = ["bitpacker1x"] }
 streaming-iterator = "0.1.5"
 
+futures = { version = "0.3", optional = true }
+
 snap = { version = "^1.0", optional = true }
 brotli = { version = "^3.3", optional = true }
 flate2 = { version = "^1.0", optional = true }
@@ -23,6 +25,7 @@ lz4 = { version = "^1.23", optional = true }
 zstd = { version = "^0.6", optional = true }
 
 [features]
-default = ["snappy", "gzip", "lz4", "zstd", "brotli"]
+default = ["snappy", "gzip", "lz4", "zstd", "brotli", "stream"]
 snappy = ["snap"]
 gzip = ["flate2"]
+stream = ["futures"]

--- a/src/serialization/write/mod.rs
+++ b/src/serialization/write/mod.rs
@@ -26,7 +26,7 @@ mod tests {
     use std::sync::Arc;
 
     use crate::tests::{alltypes_plain, alltypes_statistics};
-    use crate::write::write_file;
+    use crate::write::{write_file, DynIter};
 
     use crate::compression::CompressionCodec;
     use crate::metadata::SchemaDescriptor;
@@ -64,11 +64,10 @@ mod tests {
 
         let a = schema.columns();
 
-        let row_groups = std::iter::once(Ok(std::iter::once(Ok(std::iter::once(array_to_page(
-            &array, &options, &a[0],
+        let row_groups = std::iter::once(Ok(DynIter::new(std::iter::once(Ok(DynIter::new(
+            std::iter::once(array_to_page(&array, &options, &a[0])),
         ))))));
 
-        println!("{:#?}", a);
         let mut writer = Cursor::new(vec![]);
         write_file(&mut writer, row_groups, schema, options, None, None)?;
 

--- a/src/write/dyn_iter.rs
+++ b/src/write/dyn_iter.rs
@@ -1,0 +1,25 @@
+pub struct DynIter<'a, V> {
+    iter: Box<dyn Iterator<Item = V> + 'a>,
+}
+
+impl<'iter, V> Iterator for DynIter<'iter, V> {
+    type Item = V;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
+}
+
+impl<'iter, V> DynIter<'iter, V> {
+    pub fn new<I>(iter: I) -> Self
+    where
+        I: Iterator<Item = V> + 'iter,
+    {
+        Self {
+            iter: Box::new(iter),
+        }
+    }
+}

--- a/src/write/stream.rs
+++ b/src/write/stream.rs
@@ -1,0 +1,63 @@
+use futures::stream::Stream;
+use futures::StreamExt;
+use futures::TryStreamExt;
+
+use std::{
+    error::Error,
+    io::{Seek, Write},
+};
+
+use parquet_format::FileMetaData;
+
+pub use crate::metadata::KeyValue;
+use crate::{
+    error::{ParquetError, Result},
+    metadata::SchemaDescriptor,
+};
+
+use super::file::{end_file, start_file};
+use super::{row_group::write_row_group, RowGroupIter, WriteOptions};
+
+pub async fn write_stream<'a, W, S, E>(
+    writer: &mut W,
+    row_groups: S,
+    schema: SchemaDescriptor,
+    options: WriteOptions,
+    created_by: Option<String>,
+    key_value_metadata: Option<Vec<KeyValue>>,
+) -> Result<()>
+where
+    W: Write + Seek,
+    S: Stream<Item = std::result::Result<RowGroupIter<'a, E>, E>>,
+    E: Error + Send + Sync + 'static,
+{
+    start_file(writer)?;
+
+    let row_groups = row_groups
+        .map(|row_group| {
+            write_row_group(
+                writer,
+                schema.columns(),
+                options.compression,
+                row_group.map_err(ParquetError::from_external_error)?,
+            )
+        })
+        .try_collect::<Vec<_>>()
+        .await?;
+
+    // compute file stats
+    let num_rows = row_groups.iter().map(|group| group.num_rows).sum();
+
+    let metadata = FileMetaData::new(
+        1,
+        schema.into_thrift()?,
+        num_rows,
+        row_groups,
+        key_value_metadata,
+        created_by,
+        None,
+    );
+
+    end_file(writer, metadata)?;
+    Ok(())
+}


### PR DESCRIPTION
This generalizes the `write_file` by allowing dynamic iterators. The penalty should be low because these iterators have a low performance footprint.

Also added `write_stream`, which is the `async` version of `write_file` (for streams, like DataFusion).
