### PR TITLE
Tests and fix for get_bit_width function

### DIFF
--- a/src/encoding/mod.rs
+++ b/src/encoding/mod.rs
@@ -17,21 +17,6 @@ pub fn get_length(values: &[u8]) -> u32 {
     u32::from_le_bytes(values[0..4].try_into().unwrap())
 }
 
-/// Returns floor(log2(x))
-#[inline]
-pub fn log2(mut x: u64) -> u32 {
-    if x == 1 {
-        return 1;
-    }
-    x -= 1;
-    let mut result = 0;
-    while x > 0 {
-        x >>= 1;
-        result += 1;
-    }
-    result
-}
-
 /// Returns the ceil of value/divisor
 #[inline]
 pub fn ceil8(value: usize) -> usize {

--- a/src/read/levels.rs
+++ b/src/read/levels.rs
@@ -1,8 +1,9 @@
-use crate::encoding::{bitpacking, get_length, hybrid_rle, log2};
+use crate::encoding::{bitpacking, get_length, hybrid_rle};
 
+/// Returns the number of bits needed to store the given maximum definition or repetition level.
 #[inline]
 pub fn get_bit_width(max_level: i16) -> u32 {
-    log2(max_level as u64)
+    16 - max_level.leading_zeros()
 }
 
 enum DecoderState<'a> {
@@ -138,4 +139,26 @@ pub fn split_buffer_v2(
         &buffer[rep_level_buffer_length..rep_level_buffer_length + def_level_buffer_length],
         &buffer[rep_level_buffer_length + def_level_buffer_length..],
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::get_bit_width;
+
+    #[test]
+    fn test_get_bit_width() {
+        assert_eq!(0, get_bit_width(0));
+        assert_eq!(1, get_bit_width(1));
+        assert_eq!(2, get_bit_width(2));
+        assert_eq!(2, get_bit_width(3));
+        assert_eq!(3, get_bit_width(4));
+        assert_eq!(3, get_bit_width(5));
+        assert_eq!(3, get_bit_width(6));
+        assert_eq!(3, get_bit_width(7));
+        assert_eq!(4, get_bit_width(8));
+        assert_eq!(4, get_bit_width(15));
+
+        assert_eq!(8, get_bit_width(255));
+        assert_eq!(9, get_bit_width(256));
+    }
 }


### PR DESCRIPTION
Noticed this giving incorrect results when working on support for required lists or lists with required items. Previously, lists always assumed a maximum definition level of 3, for which the implementation returned a correct result. But for a max level of 1 or 2 the result should actually be different from the log2. At the same time the implementation can be optimized by using the `leading_zeros` intrinsic.