### PR TITLE
Add support to read async

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ thrift = { path = "../thrift/lib/rs" }
 bitpacking = { version = "0.8.2", features = ["bitpacker1x"] }
 streaming-iterator = "0.1.5"
 
+async-stream = { version = "0.3.2", optional = true }
 futures = { version = "0.3", optional = true }
 
 snap = { version = "^1.0", optional = true }
@@ -29,4 +30,4 @@ zstd = { version = "^0.9", optional = true }
 default = ["snappy", "gzip", "lz4", "zstd", "brotli", "stream"]
 snappy = ["snap"]
 gzip = ["flate2"]
-stream = ["futures"]
+stream = ["futures", "async-stream"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,7 @@ name = "parquet2"
 bench = false
 
 [dependencies]
-parquet-format = { path = "../parquet-format-rs" }
-thrift = { path = "../thrift/lib/rs" }
+parquet-format-async-temp = "0.1.0"
 bitpacking = { version = "0.8.2", features = ["bitpacker1x"] }
 streaming-iterator = "0.1.5"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ name = "parquet2"
 bench = false
 
 [dependencies]
-parquet-format = "~2.6.1"
-thrift = "0.13"
+parquet-format = { path = "../parquet-format-rs" }
+thrift = { path = "../thrift/lib/rs" }
 bitpacking = { version = "0.8.2", features = ["bitpacker1x"] }
 streaming-iterator = "0.1.5"
 

--- a/examples/s3/Cargo.toml
+++ b/examples/s3/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-parquet2 = { path = "../../", default-features = false, features = ["stream"] }
+parquet2 = { path = "../../" }
 rust-s3 = { version = "0.27.0-rc4", features = ["blocking", "futures"] }
 futures = "0.3"
 tokio = { version = "1.0.0", features = ["macros", "rt-multi-thread"] }

--- a/examples/s3/Cargo.toml
+++ b/examples/s3/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "s3"
+version = "0.1.0"
+edition = "2018"
+
+[dependencies]
+parquet2 = { path = "../../", default-features = false, features = ["stream"] }
+rust-s3 = { version = "0.27.0-rc4", features = ["blocking", "futures"] }
+futures = "0.3"
+tokio = { version = "1.0.0", features = ["macros", "rt-multi-thread"] }

--- a/examples/s3/src/main.rs
+++ b/examples/s3/src/main.rs
@@ -1,0 +1,22 @@
+use parquet2::read::read_metadata_async;
+use s3::Bucket;
+
+mod stream;
+use stream::RangedStreamer;
+
+#[tokio::main]
+async fn main() {
+    let bucket_name = "ursa-labs-taxi-data";
+    let region = "us-east-2".parse().unwrap();
+    let bucket = Bucket::new_public(bucket_name, region).unwrap();
+    let path = "2009/01/data.parquet".to_string();
+
+    let (data, _) = bucket.head_object(&path).await.unwrap();
+    let length = data.content_length.unwrap() as usize;
+
+    let mut reader = RangedStreamer::new(length, bucket, path, 1024 * 1024);
+
+    let metadata = read_metadata_async(&mut reader).await.unwrap();
+
+    println!("{}", metadata.num_rows);
+}

--- a/examples/s3/src/main.rs
+++ b/examples/s3/src/main.rs
@@ -1,11 +1,16 @@
+use futures::pin_mut;
+use futures::StreamExt;
+use parquet2::error::Result;
+use parquet2::read::get_page_stream;
 use parquet2::read::read_metadata_async;
+use parquet2::statistics::BinaryStatistics;
 use s3::Bucket;
 
 mod stream;
 use stream::RangedStreamer;
 
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<()> {
     let bucket_name = "ursa-labs-taxi-data";
     let region = "us-east-2".parse().unwrap();
     let bucket = Bucket::new_public(bucket_name, region).unwrap();
@@ -16,7 +21,23 @@ async fn main() {
 
     let mut reader = RangedStreamer::new(length, bucket, path, 1024 * 1024);
 
-    let metadata = read_metadata_async(&mut reader).await.unwrap();
+    let metadata = read_metadata_async(&mut reader).await?;
 
+    // metadata
     println!("{}", metadata.num_rows);
+
+    // pages of the first row group and first column
+    let pages = get_page_stream(&metadata, 0, 0, &mut reader, vec![]).await?;
+
+    pin_mut!(pages); // needed for iteration
+
+    let first_page = pages.next().await.unwrap()?;
+    // the page statistics
+    // first unwrap: they exist
+    let a = first_page.statistics().unwrap()?;
+    let a = a.as_any().downcast_ref::<BinaryStatistics>().unwrap();
+    println!("{:?}", a.min_value);
+    println!("{:?}", a.max_value);
+    println!("{:?}", a.null_count);
+    Ok(())
 }

--- a/examples/s3/src/main.rs
+++ b/examples/s3/src/main.rs
@@ -48,7 +48,9 @@ async fn main() -> Result<()> {
     // metadata
     println!("{}", metadata.num_rows);
 
-    // pages of the first row group and first column
+    // * first row group 
+    // * first column
+    // * do not skip any pages
     let pages = get_page_stream(&metadata, 0, 0, &mut reader, vec![], Arc::new(|_, _| true)).await?;
 
     pin_mut!(pages); // needed for iteration

--- a/examples/s3/src/main.rs
+++ b/examples/s3/src/main.rs
@@ -1,10 +1,15 @@
-use futures::future::BoxFuture;
-use futures::pin_mut;
-use futures::StreamExt;
-use parquet2::error::Result;
-use parquet2::read::get_page_stream;
-use parquet2::read::read_metadata_async;
-use parquet2::statistics::BinaryStatistics;
+use std::sync::Arc;
+
+use futures::{
+    future::BoxFuture,
+    pin_mut,
+    StreamExt
+};
+use parquet2::{
+    error::Result,
+    read::{get_page_stream, read_metadata_async},
+    statistics::BinaryStatistics,
+};
 use s3::Bucket;
 
 mod stream;
@@ -44,7 +49,7 @@ async fn main() -> Result<()> {
     println!("{}", metadata.num_rows);
 
     // pages of the first row group and first column
-    let pages = get_page_stream(&metadata, 0, 0, &mut reader, vec![]).await?;
+    let pages = get_page_stream(&metadata, 0, 0, &mut reader, vec![], Arc::new(|_, _| true)).await?;
 
     pin_mut!(pages); // needed for iteration
 

--- a/examples/s3/src/stream.rs
+++ b/examples/s3/src/stream.rs
@@ -1,0 +1,130 @@
+// Special thanks to Alice for the help: https://users.rust-lang.org/t/63019/6
+use std::io::{Result, SeekFrom};
+use std::pin::Pin;
+
+use futures::{
+    future::BoxFuture,
+    io::{AsyncRead, AsyncSeek},
+    Future,
+};
+use s3::Bucket;
+
+pub struct RangedStreamer {
+    pos: u64,
+    length: u64, // total size
+    state: State,
+    path: String,
+    min_request_size: usize, // requests have at least this size
+}
+
+impl RangedStreamer {
+    pub fn new(length: usize, bucket: Bucket, path: String, min_request_size: usize) -> Self {
+        let length = length as u64;
+        Self {
+            pos: 0,
+            length,
+            state: State::HasChunk(SeekOutput {
+                start: 0,
+                bucket,
+                data: vec![],
+            }),
+            path,
+            min_request_size,
+        }
+    }
+}
+
+async fn read_s3(start: u64, length: usize, bucket: Bucket, path: String) -> Result<SeekOutput> {
+    let (mut data, _) = bucket
+        .get_object_range(&path, start, Some(start + length as u64))
+        .await
+        .map_err(|x| std::io::Error::new(std::io::ErrorKind::Other, x.to_string()))?;
+
+    data.truncate(length);
+    Ok(SeekOutput {
+        start,
+        bucket,
+        data,
+    })
+}
+
+enum State {
+    HasChunk(SeekOutput),
+    Seeking(BoxFuture<'static, std::io::Result<SeekOutput>>),
+}
+
+struct SeekOutput {
+    start: u64,
+    bucket: Bucket,
+    data: Vec<u8>,
+}
+
+// whether `test_interval` is inside `a` (start, length).
+fn range_includes(a: (usize, usize), test_interval: (usize, usize)) -> bool {
+    if test_interval.0 < a.0 {
+        return false;
+    }
+    let test_end = test_interval.0 + test_interval.1;
+    let a_end = a.0 + a.1;
+    if test_end > a_end {
+        return false;
+    }
+    true
+}
+
+impl AsyncRead for RangedStreamer {
+    fn poll_read(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut [u8],
+    ) -> std::task::Poll<Result<usize>> {
+        let requested_range = (self.pos as usize, buf.len());
+        let min_request_size = self.min_request_size;
+        match &mut self.state {
+            State::HasChunk(output) => {
+                //let _ = self.process(buf, &output);
+                let existing_range = (output.start as usize, output.data.len());
+                if range_includes(existing_range, requested_range) {
+                    let offset = requested_range.0 - existing_range.0;
+                    buf.copy_from_slice(&output.data[offset..offset + buf.len()]);
+                    self.pos += buf.len() as u64;
+                    std::task::Poll::Ready(Ok(buf.len()))
+                } else {
+                    let future = read_s3(
+                        requested_range.0 as u64,
+                        std::cmp::max(min_request_size, requested_range.1),
+                        output.bucket.clone(),
+                        self.path.clone(),
+                    );
+                    self.state = State::Seeking(Box::pin(future));
+                    self.poll_read(cx, buf)
+                }
+            }
+            State::Seeking(ref mut future) => match Pin::new(future).poll(cx) {
+                std::task::Poll::Ready(v) => {
+                    match v {
+                        Ok(output) => self.state = State::HasChunk(output),
+                        Err(e) => return std::task::Poll::Ready(Err(e)),
+                    };
+                    self.poll_read(cx, buf)
+                }
+                std::task::Poll::Pending => std::task::Poll::Pending,
+            },
+        }
+    }
+}
+
+impl AsyncSeek for RangedStreamer {
+    fn poll_seek(
+        mut self: std::pin::Pin<&mut Self>,
+        _: &mut std::task::Context<'_>,
+        pos: std::io::SeekFrom,
+    ) -> std::task::Poll<Result<u64>> {
+        match pos {
+            SeekFrom::Start(pos) => self.pos = pos,
+            SeekFrom::End(pos) => self.pos = (self.length as i64 + pos) as u64,
+            SeekFrom::Current(pos) => self.pos = (self.pos as i64 + pos) as u64,
+        };
+        std::task::Poll::Ready(Ok(self.pos))
+    }
+}

--- a/examples/s3/src/stream.rs
+++ b/examples/s3/src/stream.rs
@@ -82,7 +82,6 @@ impl AsyncRead for RangedStreamer {
         let min_request_size = self.min_request_size;
         match &mut self.state {
             State::HasChunk(output) => {
-                //let _ = self.process(buf, &output);
                 let existing_range = (output.start as usize, output.data.len());
                 if range_includes(existing_range, requested_range) {
                     let offset = requested_range.0 - existing_range.0;

--- a/integration-tests/src/read/binary.rs
+++ b/integration-tests/src/read/binary.rs
@@ -2,7 +2,7 @@ use parquet::{
     encoding::{bitpacking, plain_byte_array, uleb128, Encoding},
     error::Result,
     metadata::ColumnDescriptor,
-    page::{BinaryPageDict, DataPage, DataPageHeader},
+    page::{BinaryPageDict, DataPage, DataPageHeader, DataPageHeaderExt},
     read::levels,
 };
 
@@ -49,14 +49,14 @@ fn read_dict_buffer(
 ) -> Vec<Option<Vec<u8>>> {
     let max_def_level = def_level_encoding.1 as u32;
     match (def_level_encoding.0, max_def_level == 0) {
-        (Encoding::RLE, true) => read_dict_buffer_impl(
+        (Encoding::Rle, true) => read_dict_buffer_impl(
             std::iter::repeat(0).take(length as usize),
             values,
             length,
             max_def_level,
             dict,
         ),
-        (Encoding::RLE, false) => {
+        (Encoding::Rle, false) => {
             let num_bits = get_bit_width(def_level_encoding.1);
             let def_levels = RLEDecoder::new(def_levels, num_bits, length);
             read_dict_buffer_impl(def_levels, values, length, max_def_level, dict)
@@ -81,7 +81,7 @@ pub fn page_dict_to_vec(
                     page.num_values() as u32,
                     dict.as_any().downcast_ref().unwrap(),
                     (
-                        &header.definition_level_encoding,
+                        &header.definition_level_encoding(),
                         descriptor.max_def_level(),
                     ),
                 ))
@@ -113,13 +113,13 @@ fn read_buffer(
 ) -> Vec<Option<Vec<u8>>> {
     let max_def_level = def_level_encoding.1 as u32;
     match (def_level_encoding.0, max_def_level == 0) {
-        (Encoding::RLE, true) => read_buffer_impl(
+        (Encoding::Rle, true) => read_buffer_impl(
             std::iter::repeat(0).take(length as usize),
             values,
             length,
             max_def_level,
         ),
-        (Encoding::RLE, false) => {
+        (Encoding::Rle, false) => {
             let num_bits = get_bit_width(def_level_encoding.1);
             let def_levels = RLEDecoder::new(def_levels, num_bits, length);
             read_buffer_impl(def_levels, values, length, max_def_level)
@@ -140,7 +140,7 @@ pub fn page_to_vec(page: &DataPage, descriptor: &ColumnDescriptor) -> Result<Vec
                     values,
                     page.num_values() as u32,
                     (
-                        &header.definition_level_encoding,
+                        &header.definition_level_encoding(),
                         descriptor.max_def_level(),
                     ),
                 ))

--- a/integration-tests/src/read/binary.rs
+++ b/integration-tests/src/read/binary.rs
@@ -49,14 +49,14 @@ fn read_dict_buffer(
 ) -> Vec<Option<Vec<u8>>> {
     let max_def_level = def_level_encoding.1 as u32;
     match (def_level_encoding.0, max_def_level == 0) {
-        (Encoding::Rle, true) => read_dict_buffer_impl(
+        (Encoding::RLE, true) => read_dict_buffer_impl(
             std::iter::repeat(0).take(length as usize),
             values,
             length,
             max_def_level,
             dict,
         ),
-        (Encoding::Rle, false) => {
+        (Encoding::RLE, false) => {
             let num_bits = get_bit_width(def_level_encoding.1);
             let def_levels = RLEDecoder::new(def_levels, num_bits, length);
             read_dict_buffer_impl(def_levels, values, length, max_def_level, dict)
@@ -113,13 +113,13 @@ fn read_buffer(
 ) -> Vec<Option<Vec<u8>>> {
     let max_def_level = def_level_encoding.1 as u32;
     match (def_level_encoding.0, max_def_level == 0) {
-        (Encoding::Rle, true) => read_buffer_impl(
+        (Encoding::RLE, true) => read_buffer_impl(
             std::iter::repeat(0).take(length as usize),
             values,
             length,
             max_def_level,
         ),
-        (Encoding::Rle, false) => {
+        (Encoding::RLE, false) => {
             let num_bits = get_bit_width(def_level_encoding.1);
             let def_levels = RLEDecoder::new(def_levels, num_bits, length);
             read_buffer_impl(def_levels, values, length, max_def_level)

--- a/integration-tests/src/read/primitive.rs
+++ b/integration-tests/src/read/primitive.rs
@@ -6,7 +6,7 @@ use parquet::{
     encoding::{bitpacking, uleb128, Encoding},
     error::{ParquetError, Result},
     metadata::ColumnDescriptor,
-    page::{DataPage, DataPageHeader, PrimitivePageDict},
+    page::{DataPage, DataPageHeader, DataPageHeaderExt, PrimitivePageDict},
     read::levels::{get_bit_width, split_buffer_v1, split_buffer_v2, RLEDecoder},
     types::NativeType,
 };
@@ -43,12 +43,12 @@ fn read_buffer<T: NativeType>(
 ) -> Vec<Option<T>> {
     let max_def_level = def_level_encoding.1 as u32;
     match (def_level_encoding.0, max_def_level == 0) {
-        (Encoding::RLE, true) => read_buffer_impl(
+        (Encoding::Rle, true) => read_buffer_impl(
             std::iter::repeat(0).take(length as usize),
             values,
             max_def_level,
         ),
-        (Encoding::RLE, false) => {
+        (Encoding::Rle, false) => {
             let num_bits = get_bit_width(def_level_encoding.1);
             let def_levels = RLEDecoder::new(def_levels, num_bits, length);
             read_buffer_impl(def_levels, values, max_def_level)
@@ -90,14 +90,14 @@ fn read_dict_buffer<'a, T: NativeType>(
 ) -> Vec<Option<T>> {
     let max_def_level = def_level_encoding.1 as u32;
     match (def_level_encoding.0, max_def_level == 0) {
-        (Encoding::RLE, true) => read_dict_buffer_impl(
+        (Encoding::Rle, true) => read_dict_buffer_impl(
             std::iter::repeat(0).take(length as usize),
             values,
             length,
             max_def_level,
             dict,
         ),
-        (Encoding::RLE, false) => {
+        (Encoding::Rle, false) => {
             let num_bits = get_bit_width(def_level_encoding.1);
             let def_levels = RLEDecoder::new(def_levels, num_bits, length);
             read_dict_buffer_impl(def_levels, values, length, max_def_level, dict)
@@ -122,7 +122,7 @@ pub fn page_dict_to_vec<T: NativeType>(
                     page.num_values() as u32,
                     dict.as_any().downcast_ref().unwrap(),
                     (
-                        &header.definition_level_encoding,
+                        &header.definition_level_encoding(),
                         descriptor.max_def_level(),
                     ),
                 ))
@@ -132,7 +132,7 @@ pub fn page_dict_to_vec<T: NativeType>(
             )),
             _ => todo!(),
         },
-        DataPageHeader::V2(header) => match (&header.encoding, &page.dictionary_page()) {
+        DataPageHeader::V2(header) => match (&header.encoding(), &page.dictionary_page()) {
             (Encoding::RleDictionary, Some(dict)) | (Encoding::PlainDictionary, Some(dict)) => {
                 let (_, def_levels, values) = split_buffer_v2(
                     page.buffer(),
@@ -144,7 +144,7 @@ pub fn page_dict_to_vec<T: NativeType>(
                     values,
                     page.num_values() as u32,
                     dict.as_any().downcast_ref().unwrap(),
-                    (&Encoding::RLE, descriptor.max_def_level()),
+                    (&Encoding::Rle, descriptor.max_def_level()),
                 ))
             }
             _ => todo!(),
@@ -158,7 +158,7 @@ pub fn page_to_vec<T: NativeType>(
 ) -> Result<Vec<Option<T>>> {
     assert_eq!(descriptor.max_rep_level(), 0);
     match page.header() {
-        DataPageHeader::V1(header) => match (&header.encoding, &page.dictionary_page()) {
+        DataPageHeader::V1(header) => match (&header.encoding(), &page.dictionary_page()) {
             (Encoding::Plain, None) => {
                 let (_, def_levels, values) =
                     split_buffer_v1(page.buffer(), false, descriptor.max_def_level() > 0);
@@ -167,14 +167,14 @@ pub fn page_to_vec<T: NativeType>(
                     values,
                     page.num_values() as u32,
                     (
-                        &header.definition_level_encoding,
+                        &header.definition_level_encoding(),
                         descriptor.max_def_level(),
                     ),
                 ))
             }
             _ => todo!(),
         },
-        DataPageHeader::V2(header) => match (&header.encoding, &page.dictionary_page()) {
+        DataPageHeader::V2(header) => match (&header.encoding(), &page.dictionary_page()) {
             (Encoding::Plain, None) => {
                 let (_, def_levels, values) = split_buffer_v2(
                     page.buffer(),
@@ -185,7 +185,7 @@ pub fn page_to_vec<T: NativeType>(
                     def_levels,
                     values,
                     page.num_values() as u32,
-                    (&Encoding::RLE, descriptor.max_def_level()),
+                    (&Encoding::Rle, descriptor.max_def_level()),
                 ))
             }
             _ => todo!(),

--- a/integration-tests/src/read/primitive.rs
+++ b/integration-tests/src/read/primitive.rs
@@ -43,12 +43,12 @@ fn read_buffer<T: NativeType>(
 ) -> Vec<Option<T>> {
     let max_def_level = def_level_encoding.1 as u32;
     match (def_level_encoding.0, max_def_level == 0) {
-        (Encoding::Rle, true) => read_buffer_impl(
+        (Encoding::RLE, true) => read_buffer_impl(
             std::iter::repeat(0).take(length as usize),
             values,
             max_def_level,
         ),
-        (Encoding::Rle, false) => {
+        (Encoding::RLE, false) => {
             let num_bits = get_bit_width(def_level_encoding.1);
             let def_levels = RLEDecoder::new(def_levels, num_bits, length);
             read_buffer_impl(def_levels, values, max_def_level)
@@ -90,14 +90,14 @@ fn read_dict_buffer<'a, T: NativeType>(
 ) -> Vec<Option<T>> {
     let max_def_level = def_level_encoding.1 as u32;
     match (def_level_encoding.0, max_def_level == 0) {
-        (Encoding::Rle, true) => read_dict_buffer_impl(
+        (Encoding::RLE, true) => read_dict_buffer_impl(
             std::iter::repeat(0).take(length as usize),
             values,
             length,
             max_def_level,
             dict,
         ),
-        (Encoding::Rle, false) => {
+        (Encoding::RLE, false) => {
             let num_bits = get_bit_width(def_level_encoding.1);
             let def_levels = RLEDecoder::new(def_levels, num_bits, length);
             read_dict_buffer_impl(def_levels, values, length, max_def_level, dict)
@@ -144,7 +144,7 @@ pub fn page_dict_to_vec<T: NativeType>(
                     values,
                     page.num_values() as u32,
                     dict.as_any().downcast_ref().unwrap(),
-                    (&Encoding::Rle, descriptor.max_def_level()),
+                    (&Encoding::RLE, descriptor.max_def_level()),
                 ))
             }
             _ => todo!(),
@@ -185,7 +185,7 @@ pub fn page_to_vec<T: NativeType>(
                     def_levels,
                     values,
                     page.num_values() as u32,
-                    (&Encoding::Rle, descriptor.max_def_level()),
+                    (&Encoding::RLE, descriptor.max_def_level()),
                 ))
             }
             _ => todo!(),

--- a/integration-tests/src/read/primitive_nested.rs
+++ b/integration-tests/src/read/primitive_nested.rs
@@ -79,14 +79,14 @@ fn read_array_impl<T: NativeType, I: Iterator<Item = i64>>(
         (rep_level_encoding.0, max_rep_level == 0),
         (def_level_encoding.0, max_def_level == 0),
     ) {
-        ((Encoding::Rle, true), (Encoding::Rle, true)) => compose_array(
+        ((Encoding::RLE, true), (Encoding::RLE, true)) => compose_array(
             std::iter::repeat(0).take(length as usize),
             std::iter::repeat(0).take(length as usize),
             max_rep_level,
             max_def_level,
             values,
         ),
-        ((Encoding::Rle, false), (Encoding::Rle, true)) => {
+        ((Encoding::RLE, false), (Encoding::RLE, true)) => {
             let num_bits = get_bit_width(rep_level_encoding.1);
             let rep_levels = RLEDecoder::new(rep_levels, num_bits, length);
             compose_array(
@@ -97,7 +97,7 @@ fn read_array_impl<T: NativeType, I: Iterator<Item = i64>>(
                 values,
             )
         }
-        ((Encoding::Rle, true), (Encoding::Rle, false)) => {
+        ((Encoding::RLE, true), (Encoding::RLE, false)) => {
             let num_bits = get_bit_width(def_level_encoding.1);
             let def_levels = RLEDecoder::new(def_levels, num_bits, length);
             compose_array(
@@ -108,7 +108,7 @@ fn read_array_impl<T: NativeType, I: Iterator<Item = i64>>(
                 values,
             )
         }
-        ((Encoding::Rle, false), (Encoding::Rle, false)) => {
+        ((Encoding::RLE, false), (Encoding::RLE, false)) => {
             let rep_levels =
                 RLEDecoder::new(rep_levels, get_bit_width(rep_level_encoding.1), length);
             let def_levels =

--- a/integration-tests/src/write/mod.rs
+++ b/integration-tests/src/write/mod.rs
@@ -29,7 +29,7 @@ mod tests {
 
     use crate::tests::{alltypes_plain, alltypes_statistics};
 
-    use parquet::compression::CompressionCodec;
+    use parquet::compression::Compression;
     use parquet::error::Result;
     use parquet::metadata::SchemaDescriptor;
     use parquet::statistics::Statistics;
@@ -47,7 +47,7 @@ mod tests {
 
         let options = WriteOptions {
             write_statistics: true,
-            compression: CompressionCodec::Uncompressed,
+            compression: Compression::Uncompressed,
             version: Version::V1,
         };
 
@@ -136,7 +136,7 @@ mod tests2 {
 
     use crate::write::primitive::array_to_page_v1;
     use parquet::{
-        compression::CompressionCodec,
+        compression::Compression,
         error::Result,
         metadata::SchemaDescriptor,
         read::read_metadata,
@@ -157,7 +157,7 @@ mod tests2 {
 
         let options = WriteOptions {
             write_statistics: false,
-            compression: CompressionCodec::Uncompressed,
+            compression: Compression::Uncompressed,
             version: Version::V1,
         };
 

--- a/integration-tests/src/write/primitive.rs
+++ b/integration-tests/src/write/primitive.rs
@@ -77,8 +77,8 @@ pub fn array_to_page_v1<T: NativeType>(
     let header = DataPageHeaderV1 {
         num_values: array.len() as i32,
         encoding: Encoding::Plain,
-        definition_level_encoding: Encoding::Rle,
-        repetition_level_encoding: Encoding::Rle,
+        definition_level_encoding: Encoding::RLE,
+        repetition_level_encoding: Encoding::RLE,
         statistics,
     };
 

--- a/integration-tests/src/write/primitive.rs
+++ b/integration-tests/src/write/primitive.rs
@@ -76,9 +76,9 @@ pub fn array_to_page_v1<T: NativeType>(
 
     let header = DataPageHeaderV1 {
         num_values: array.len() as i32,
-        encoding: Encoding::Plain,
-        definition_level_encoding: Encoding::RLE,
-        repetition_level_encoding: Encoding::RLE,
+        encoding: Encoding::Plain.into(),
+        definition_level_encoding: Encoding::Rle.into(),
+        repetition_level_encoding: Encoding::Rle.into(),
         statistics,
     };
 

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-pub use parquet_format_async_temp::CompressionCodec;
+pub use super::parquet_bridge::Compression;
 
 use crate::error::{ParquetError, Result};
 
@@ -35,23 +35,20 @@ pub trait Codec: std::fmt::Debug {
 /// Given the compression type `codec`, returns a codec used to compress and decompress
 /// bytes for the compression type.
 /// This returns `None` if the codec type is `UNCOMPRESSED`.
-pub fn create_codec(codec: &CompressionCodec) -> Result<Option<Box<dyn Codec>>> {
+pub fn create_codec(codec: &Compression) -> Result<Option<Box<dyn Codec>>> {
     match *codec {
         #[cfg(feature = "brotli")]
-        CompressionCodec::BROTLI => Ok(Some(Box::new(BrotliCodec::new()))),
+        Compression::Brotli => Ok(Some(Box::new(BrotliCodec::new()))),
         #[cfg(feature = "gzip")]
-        CompressionCodec::GZIP => Ok(Some(Box::new(GZipCodec::new()))),
+        Compression::Gzip => Ok(Some(Box::new(GZipCodec::new()))),
         #[cfg(feature = "snappy")]
-        CompressionCodec::SNAPPY => Ok(Some(Box::new(SnappyCodec::new()))),
+        Compression::Snappy => Ok(Some(Box::new(SnappyCodec::new()))),
         #[cfg(feature = "lz4")]
-        CompressionCodec::LZ4 => Ok(Some(Box::new(Lz4Codec::new()))),
+        Compression::Lz4 => Ok(Some(Box::new(Lz4Codec::new()))),
         #[cfg(feature = "zstd")]
-        CompressionCodec::ZSTD => Ok(Some(Box::new(ZstdCodec::new()))),
-        CompressionCodec::UNCOMPRESSED => Ok(None),
-        _ => Err(general_err!(
-            "CompressionCodec {:?} is not installed",
-            codec
-        )),
+        Compression::Zsld => Ok(Some(Box::new(ZstdCodec::new()))),
+        Compression::Uncompressed => Ok(None),
+        _ => Err(general_err!("Compression {:?} is not installed", codec)),
     }
 }
 
@@ -249,7 +246,7 @@ mod zstd_codec {
         }
     }
 
-    /// CompressionCodec level (1-21) for ZSTD. Choose 1 here for better compression speed.
+    /// Compression level (1-21) for ZSTD. Choose 1 here for better compression speed.
     const ZSTD_COMPRESSION_LEVEL: i32 = 1;
 
     impl Codec for ZstdCodec {
@@ -275,7 +272,7 @@ pub use zstd_codec::*;
 mod tests {
     use super::*;
 
-    fn test_roundtrip(c: CompressionCodec, data: &[u8]) {
+    fn test_roundtrip(c: Compression, data: &[u8]) {
         let mut c1 = create_codec(&c).unwrap().unwrap();
         let mut c2 = create_codec(&c).unwrap().unwrap();
 
@@ -302,7 +299,7 @@ mod tests {
         assert_eq!(data, decompressed.as_slice());
     }
 
-    fn test_codec(c: CompressionCodec) {
+    fn test_codec(c: Compression) {
         let sizes = vec![100, 10000, 100000];
         for size in sizes {
             let data = (0..size).map(|x| (x % 255) as u8).collect::<Vec<_>>();
@@ -312,26 +309,26 @@ mod tests {
 
     #[test]
     fn test_codec_snappy() {
-        test_codec(CompressionCodec::SNAPPY);
+        test_codec(Compression::Snappy);
     }
 
     #[test]
     fn test_codec_gzip() {
-        test_codec(CompressionCodec::GZIP);
+        test_codec(Compression::Gzip);
     }
 
     #[test]
     fn test_codec_brotli() {
-        test_codec(CompressionCodec::BROTLI);
+        test_codec(Compression::Brotli);
     }
 
     #[test]
     fn test_codec_lz4() {
-        test_codec(CompressionCodec::LZ4);
+        test_codec(Compression::Lz4);
     }
 
     #[test]
     fn test_codec_zstd() {
-        test_codec(CompressionCodec::ZSTD);
+        test_codec(Compression::Zsld);
     }
 }

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-pub use parquet_format::CompressionCodec;
+pub use parquet_format_async_temp::CompressionCodec;
 
 use crate::error::{ParquetError, Result};
 

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -36,19 +36,18 @@ pub trait Codec: std::fmt::Debug {
 /// bytes for the compression type.
 /// This returns `None` if the codec type is `UNCOMPRESSED`.
 pub fn create_codec(codec: &CompressionCodec) -> Result<Option<Box<dyn Codec>>> {
-    use CompressionCodec::*;
     match codec {
         #[cfg(feature = "brotli")]
-        Brotli => Ok(Some(Box::new(BrotliCodec::new()))),
+        &CompressionCodec::BROTLI => Ok(Some(Box::new(BrotliCodec::new()))),
         #[cfg(feature = "gzip")]
-        Gzip => Ok(Some(Box::new(GZipCodec::new()))),
+        &CompressionCodec::GZIP => Ok(Some(Box::new(GZipCodec::new()))),
         #[cfg(feature = "snappy")]
-        Snappy => Ok(Some(Box::new(SnappyCodec::new()))),
+        &CompressionCodec::SNAPPY => Ok(Some(Box::new(SnappyCodec::new()))),
         #[cfg(feature = "lz4")]
-        Lz4 => Ok(Some(Box::new(Lz4Codec::new()))),
+        &CompressionCodec::LZ4 => Ok(Some(Box::new(Lz4Codec::new()))),
         #[cfg(feature = "zstd")]
-        Zstd => Ok(Some(Box::new(ZstdCodec::new()))),
-        Uncompressed => Ok(None),
+        &CompressionCodec::ZSTD => Ok(Some(Box::new(ZstdCodec::new()))),
+        &CompressionCodec::UNCOMPRESSED => Ok(None),
         _ => Err(general_err!(
             "CompressionCodec {:?} is not installed",
             codec

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -36,18 +36,18 @@ pub trait Codec: std::fmt::Debug {
 /// bytes for the compression type.
 /// This returns `None` if the codec type is `UNCOMPRESSED`.
 pub fn create_codec(codec: &CompressionCodec) -> Result<Option<Box<dyn Codec>>> {
-    match codec {
+    match *codec {
         #[cfg(feature = "brotli")]
-        &CompressionCodec::BROTLI => Ok(Some(Box::new(BrotliCodec::new()))),
+        CompressionCodec::BROTLI => Ok(Some(Box::new(BrotliCodec::new()))),
         #[cfg(feature = "gzip")]
-        &CompressionCodec::GZIP => Ok(Some(Box::new(GZipCodec::new()))),
+        CompressionCodec::GZIP => Ok(Some(Box::new(GZipCodec::new()))),
         #[cfg(feature = "snappy")]
-        &CompressionCodec::SNAPPY => Ok(Some(Box::new(SnappyCodec::new()))),
+        CompressionCodec::SNAPPY => Ok(Some(Box::new(SnappyCodec::new()))),
         #[cfg(feature = "lz4")]
-        &CompressionCodec::LZ4 => Ok(Some(Box::new(Lz4Codec::new()))),
+        CompressionCodec::LZ4 => Ok(Some(Box::new(Lz4Codec::new()))),
         #[cfg(feature = "zstd")]
-        &CompressionCodec::ZSTD => Ok(Some(Box::new(ZstdCodec::new()))),
-        &CompressionCodec::UNCOMPRESSED => Ok(None),
+        CompressionCodec::ZSTD => Ok(Some(Box::new(ZstdCodec::new()))),
+        CompressionCodec::UNCOMPRESSED => Ok(None),
         _ => Err(general_err!(
             "CompressionCodec {:?} is not installed",
             codec
@@ -312,26 +312,26 @@ mod tests {
 
     #[test]
     fn test_codec_snappy() {
-        test_codec(CompressionCodec::Snappy);
+        test_codec(CompressionCodec::SNAPPY);
     }
 
     #[test]
     fn test_codec_gzip() {
-        test_codec(CompressionCodec::Gzip);
+        test_codec(CompressionCodec::GZIP);
     }
 
     #[test]
     fn test_codec_brotli() {
-        test_codec(CompressionCodec::Brotli);
+        test_codec(CompressionCodec::BROTLI);
     }
 
     #[test]
     fn test_codec_lz4() {
-        test_codec(CompressionCodec::Lz4);
+        test_codec(CompressionCodec::LZ4);
     }
 
     #[test]
     fn test_codec_zstd() {
-        test_codec(CompressionCodec::Zstd);
+        test_codec(CompressionCodec::ZSTD);
     }
 }

--- a/src/encoding/mod.rs
+++ b/src/encoding/mod.rs
@@ -9,7 +9,7 @@ pub mod plain_byte_array;
 pub mod uleb128;
 pub mod zigzag_leb128;
 
-pub use parquet_format::Encoding;
+pub use parquet_format_async_temp::Encoding;
 
 /// # Panics
 /// This function panics iff `values.len() < 4`.

--- a/src/encoding/mod.rs
+++ b/src/encoding/mod.rs
@@ -9,7 +9,7 @@ pub mod plain_byte_array;
 pub mod uleb128;
 pub mod zigzag_leb128;
 
-pub use parquet_format_async_temp::Encoding;
+pub use crate::parquet_bridge::Encoding;
 
 /// # Panics
 /// This function panics iff `values.len() < 4`.

--- a/src/error.rs
+++ b/src/error.rs
@@ -42,8 +42,8 @@ impl From<snap::Error> for ParquetError {
     }
 }
 
-impl From<thrift::Error> for ParquetError {
-    fn from(e: thrift::Error) -> ParquetError {
+impl From<parquet_format_async_temp::thrift::Error> for ParquetError {
+    fn from(e: parquet_format_async_temp::thrift::Error) -> ParquetError {
         ParquetError::General(format!("underlying thrift error: {}", e))
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod compression;
 pub mod encoding;
 pub mod metadata;
 pub mod page;
+mod parquet_bridge;
 pub mod read;
 pub mod schema;
 pub mod statistics;

--- a/src/metadata/column_chunk_metadata.rs
+++ b/src/metadata/column_chunk_metadata.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use parquet_format::{ColumnChunk, ColumnMetaData, Encoding};
+use parquet_format_async_temp::{ColumnChunk, ColumnMetaData, Encoding};
 
 use super::column_descriptor::ColumnDescriptor;
 use crate::error::Result;

--- a/src/metadata/column_chunk_metadata.rs
+++ b/src/metadata/column_chunk_metadata.rs
@@ -1,3 +1,4 @@
+use std::convert::TryInto;
 use std::sync::Arc;
 
 use parquet_format_async_temp::{ColumnChunk, ColumnMetaData, Encoding};
@@ -6,7 +7,7 @@ use super::column_descriptor::ColumnDescriptor;
 use crate::error::Result;
 use crate::schema::types::{ParquetType, PhysicalType};
 use crate::statistics::{deserialize_statistics, Statistics};
-use crate::{compression::CompressionCodec, schema::types::Type};
+use crate::{compression::Compression, schema::types::Type};
 
 /// Metadata for a column chunk.
 // This contains the `ColumnDescriptor` associated with the chunk so that deserializers have
@@ -69,9 +70,9 @@ impl ColumnChunkMetaData {
         self.column_metadata().num_values
     }
 
-    /// CompressionCodec for this column.
-    pub fn compression(&self) -> &CompressionCodec {
-        &self.column_metadata().codec
+    /// [`Compression`] for this column.
+    pub fn compression(&self) -> Compression {
+        self.column_metadata().codec.try_into().unwrap()
     }
 
     /// Returns the total compressed data size of this column chunk.

--- a/src/metadata/file_metadata.rs
+++ b/src/metadata/file_metadata.rs
@@ -91,6 +91,8 @@ impl FileMetaData {
             key_value_metadata: self.key_value_metadata,
             created_by: self.created_by,
             column_orders: None, // todo
+            encryption_algorithm: None,
+            footer_signing_key_metadata: None,
         })
     }
 }

--- a/src/metadata/file_metadata.rs
+++ b/src/metadata/file_metadata.rs
@@ -1,10 +1,10 @@
 use super::{column_order::ColumnOrder, schema_descriptor::SchemaDescriptor, RowGroupMetaData};
 use crate::error::Result;
 
-pub type KeyValue = parquet_format::KeyValue;
+pub type KeyValue = parquet_format_async_temp::KeyValue;
 
 /// Metadata for a Parquet file.
-// This is almost equal to `parquet_format::FileMetaData` but contains the descriptors,
+// This is almost equal to `parquet_format_async_temp::FileMetaData` but contains the descriptors,
 // which are crucial to deserialize pages.
 #[derive(Debug, Clone)]
 pub struct FileMetaData {
@@ -78,8 +78,8 @@ impl FileMetaData {
             .unwrap_or(ColumnOrder::Undefined)
     }
 
-    pub fn into_thrift(self) -> Result<parquet_format::FileMetaData> {
-        Ok(parquet_format::FileMetaData {
+    pub fn into_thrift(self) -> Result<parquet_format_async_temp::FileMetaData> {
+        Ok(parquet_format_async_temp::FileMetaData {
             version: self.version,
             schema: self.schema_descr.into_thrift()?,
             num_rows: self.num_rows as i64,

--- a/src/metadata/row_metadata.rs
+++ b/src/metadata/row_metadata.rs
@@ -69,6 +69,9 @@ impl RowGroupMetaData {
             total_byte_size: self.total_byte_size,
             num_rows: self.num_rows,
             sorting_columns: None,
+            file_offset: None,
+            total_compressed_size: None,
+            ordinal: None,
         }
     }
 }

--- a/src/metadata/row_metadata.rs
+++ b/src/metadata/row_metadata.rs
@@ -1,4 +1,4 @@
-use parquet_format::RowGroup;
+use parquet_format_async_temp::RowGroup;
 
 use super::{column_chunk_metadata::ColumnChunkMetaData, schema_descriptor::SchemaDescriptor};
 use crate::error::Result;

--- a/src/metadata/schema_descriptor.rs
+++ b/src/metadata/schema_descriptor.rs
@@ -1,4 +1,4 @@
-use parquet_format::SchemaElement;
+use parquet_format_async_temp::SchemaElement;
 
 use crate::{
     error::ParquetError,

--- a/src/metadata/schema_descriptor.rs
+++ b/src/metadata/schema_descriptor.rs
@@ -2,10 +2,7 @@ use parquet_format_async_temp::SchemaElement;
 
 use crate::{
     error::ParquetError,
-    schema::{
-        io_message::from_message,
-        types::{ParquetType, Repetition},
-    },
+    schema::{io_message::from_message, types::ParquetType, Repetition},
 };
 use crate::{error::Result, schema::types::BasicTypeInfo};
 
@@ -66,7 +63,7 @@ impl SchemaDescriptor {
 
     pub(crate) fn into_thrift(self) -> Result<Vec<SchemaElement>> {
         ParquetType::GroupType {
-            basic_info: BasicTypeInfo::new(self.name, Repetition::OPTIONAL, None, true),
+            basic_info: BasicTypeInfo::new(self.name, Repetition::Optional, None, true),
             logical_type: None,
             converted_type: None,
             fields: self.fields,
@@ -106,10 +103,10 @@ fn build_tree<'a>(
 ) {
     path_so_far.push(tp.name());
     match *tp.get_basic_info().repetition() {
-        Repetition::OPTIONAL => {
+        Repetition::Optional => {
             max_def_level += 1;
         }
-        Repetition::REPEATED => {
+        Repetition::Repeated => {
             max_def_level += 1;
             max_rep_level += 1;
         }

--- a/src/metadata/schema_descriptor.rs
+++ b/src/metadata/schema_descriptor.rs
@@ -66,7 +66,7 @@ impl SchemaDescriptor {
 
     pub(crate) fn into_thrift(self) -> Result<Vec<SchemaElement>> {
         ParquetType::GroupType {
-            basic_info: BasicTypeInfo::new(self.name, Repetition::Optional, None, true),
+            basic_info: BasicTypeInfo::new(self.name, Repetition::OPTIONAL, None, true),
             logical_type: None,
             converted_type: None,
             fields: self.fields,
@@ -106,10 +106,10 @@ fn build_tree<'a>(
 ) {
     path_so_far.push(tp.name());
     match tp.get_basic_info().repetition() {
-        Repetition::Optional => {
+        &Repetition::OPTIONAL => {
             max_def_level += 1;
         }
-        Repetition::Repeated => {
+        &Repetition::REPEATED => {
             max_def_level += 1;
             max_rep_level += 1;
         }

--- a/src/metadata/schema_descriptor.rs
+++ b/src/metadata/schema_descriptor.rs
@@ -105,11 +105,11 @@ fn build_tree<'a>(
     path_so_far: &mut Vec<&'a str>,
 ) {
     path_so_far.push(tp.name());
-    match tp.get_basic_info().repetition() {
-        &Repetition::OPTIONAL => {
+    match *tp.get_basic_info().repetition() {
+        Repetition::OPTIONAL => {
             max_def_level += 1;
         }
-        &Repetition::REPEATED => {
+        Repetition::REPEATED => {
             max_def_level += 1;
             max_rep_level += 1;
         }

--- a/src/metadata/sort.rs
+++ b/src/metadata/sort.rs
@@ -1,4 +1,4 @@
-use parquet_format::LogicalType;
+use parquet_format_async_temp::LogicalType;
 
 use crate::schema::types::{PhysicalType, PrimitiveConvertedType};
 

--- a/src/page/mod.rs
+++ b/src/page/mod.rs
@@ -3,9 +3,9 @@ pub use page_dict::*;
 
 use std::sync::Arc;
 
-use parquet_format::CompressionCodec;
-use parquet_format::Encoding;
-pub use parquet_format::{
+use parquet_format_async_temp::CompressionCodec;
+use parquet_format_async_temp::Encoding;
+pub use parquet_format_async_temp::{
     DataPageHeader as DataPageHeaderV1, DataPageHeaderV2, PageHeader as ParquetPageHeader,
 };
 

--- a/src/page/mod.rs
+++ b/src/page/mod.rs
@@ -65,10 +65,7 @@ impl CompressedDataPage {
     }
 
     pub fn num_values(&self) -> usize {
-        match &self.header {
-            DataPageHeader::V1(d) => d.num_values as usize,
-            DataPageHeader::V2(d) => d.num_values as usize,
-        }
+        self.header.num_values()
     }
 
     /// Decodes the raw statistics into a statistics
@@ -94,6 +91,15 @@ impl CompressedDataPage {
 pub enum DataPageHeader {
     V1(DataPageHeaderV1),
     V2(DataPageHeaderV2),
+}
+
+impl DataPageHeader {
+    pub fn num_values(&self) -> usize {
+        match &self {
+            DataPageHeader::V1(d) => d.num_values as usize,
+            DataPageHeader::V2(d) => d.num_values as usize,
+        }
+    }
 }
 
 /// A [`DataPage`] is an uncompressed, encoded representation of a Parquet data page. It holds actual data
@@ -134,10 +140,7 @@ impl DataPage {
     }
 
     pub fn num_values(&self) -> usize {
-        match &self.header {
-            DataPageHeader::V1(d) => d.num_values as usize,
-            DataPageHeader::V2(d) => d.num_values as usize,
-        }
+        self.header.num_values()
     }
 
     pub fn encoding(&self) -> Encoding {

--- a/src/page/page_dict/mod.rs
+++ b/src/page/page_dict/mod.rs
@@ -8,7 +8,7 @@ pub use primitive::PrimitivePageDict;
 
 use std::{any::Any, sync::Arc};
 
-use parquet_format::CompressionCodec;
+use parquet_format_async_temp::CompressionCodec;
 
 use crate::compression::create_codec;
 use crate::error::{ParquetError, Result};

--- a/src/page/page_dict/mod.rs
+++ b/src/page/page_dict/mod.rs
@@ -8,9 +8,7 @@ pub use primitive::PrimitivePageDict;
 
 use std::{any::Any, sync::Arc};
 
-use parquet_format_async_temp::CompressionCodec;
-
-use crate::compression::create_codec;
+use crate::compression::{create_codec, Compression};
 use crate::error::{ParquetError, Result};
 use crate::schema::types::PhysicalType;
 
@@ -37,7 +35,7 @@ impl CompressedDictPage {
 pub fn read_dict_page(
     buf: &[u8],
     num_values: u32,
-    compression: (CompressionCodec, usize),
+    compression: (Compression, usize),
     is_sorted: bool,
     physical_type: &PhysicalType,
 ) -> Result<Arc<dyn DictPage>> {

--- a/src/parquet_bridge.rs
+++ b/src/parquet_bridge.rs
@@ -1,0 +1,227 @@
+// Bridges structs from thrift-generated code to rust enums.
+use std::convert::TryFrom;
+use std::convert::TryInto;
+
+use crate::error::ParquetError;
+use parquet_format_async_temp::CompressionCodec;
+use parquet_format_async_temp::DataPageHeader;
+use parquet_format_async_temp::DataPageHeaderV2;
+use parquet_format_async_temp::Encoding as ParquetEncoding;
+use parquet_format_async_temp::FieldRepetitionType;
+use parquet_format_async_temp::PageType as ParquetPageType;
+
+#[derive(Debug, Eq, PartialEq, Hash, Clone, Copy)]
+pub enum Repetition {
+    Required,
+    Optional,
+    Repeated,
+}
+
+impl TryFrom<FieldRepetitionType> for Repetition {
+    type Error = ParquetError;
+
+    fn try_from(repetition: FieldRepetitionType) -> Result<Self, Self::Error> {
+        Ok(match repetition {
+            FieldRepetitionType::REQUIRED => Repetition::Required,
+            FieldRepetitionType::OPTIONAL => Repetition::Optional,
+            FieldRepetitionType::REPEATED => Repetition::Repeated,
+            _ => return Err(ParquetError::OutOfSpec("Thrift out of range".to_string())),
+        })
+    }
+}
+
+impl From<Repetition> for FieldRepetitionType {
+    fn from(repetition: Repetition) -> Self {
+        match repetition {
+            Repetition::Required => FieldRepetitionType::REQUIRED,
+            Repetition::Optional => FieldRepetitionType::OPTIONAL,
+            Repetition::Repeated => FieldRepetitionType::REPEATED,
+        }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Hash, Clone, Copy)]
+pub enum Compression {
+    Uncompressed,
+    Snappy,
+    Gzip,
+    Lzo,
+    Brotli,
+    Lz4,
+    Zsld,
+}
+
+impl TryFrom<CompressionCodec> for Compression {
+    type Error = ParquetError;
+
+    fn try_from(codec: CompressionCodec) -> Result<Self, Self::Error> {
+        Ok(match codec {
+            CompressionCodec::UNCOMPRESSED => Compression::Uncompressed,
+            CompressionCodec::SNAPPY => Compression::Snappy,
+            CompressionCodec::GZIP => Compression::Gzip,
+            CompressionCodec::LZO => Compression::Lzo,
+            CompressionCodec::BROTLI => Compression::Brotli,
+            CompressionCodec::LZ4 => Compression::Lz4,
+            CompressionCodec::ZSTD => Compression::Zsld,
+            _ => return Err(ParquetError::OutOfSpec("Thrift out of range".to_string())),
+        })
+    }
+}
+
+impl From<Compression> for CompressionCodec {
+    fn from(codec: Compression) -> Self {
+        match codec {
+            Compression::Uncompressed => CompressionCodec::UNCOMPRESSED,
+            Compression::Snappy => CompressionCodec::SNAPPY,
+            Compression::Gzip => CompressionCodec::GZIP,
+            Compression::Lzo => CompressionCodec::LZO,
+            Compression::Brotli => CompressionCodec::BROTLI,
+            Compression::Lz4 => CompressionCodec::LZ4,
+            Compression::Zsld => CompressionCodec::ZSTD,
+        }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Hash, Clone, Copy)]
+pub enum PageType {
+    DataPage,
+    DataPageV2,
+    DictionaryPage,
+    IndexPage,
+}
+
+impl TryFrom<ParquetPageType> for PageType {
+    type Error = ParquetError;
+
+    fn try_from(type_: ParquetPageType) -> Result<Self, Self::Error> {
+        Ok(match type_ {
+            ParquetPageType::DATA_PAGE => PageType::DataPage,
+            ParquetPageType::DATA_PAGE_V2 => PageType::DataPageV2,
+            ParquetPageType::DICTIONARY_PAGE => PageType::DictionaryPage,
+            ParquetPageType::INDEX_PAGE => PageType::IndexPage,
+            _ => return Err(ParquetError::OutOfSpec("Thrift out of range".to_string())),
+        })
+    }
+}
+
+impl From<PageType> for ParquetPageType {
+    fn from(type_: PageType) -> Self {
+        match type_ {
+            PageType::DataPage => ParquetPageType::DATA_PAGE,
+            PageType::DataPageV2 => ParquetPageType::DATA_PAGE_V2,
+            PageType::DictionaryPage => ParquetPageType::DICTIONARY_PAGE,
+            PageType::IndexPage => ParquetPageType::INDEX_PAGE,
+        }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Hash, Clone, Copy)]
+pub enum Encoding {
+    /// Default encoding.
+    /// BOOLEAN - 1 bit per value. 0 is false; 1 is true.
+    /// INT32 - 4 bytes per value.  Stored as little-endian.
+    /// INT64 - 8 bytes per value.  Stored as little-endian.
+    /// FLOAT - 4 bytes per value.  IEEE. Stored as little-endian.
+    /// DOUBLE - 8 bytes per value.  IEEE. Stored as little-endian.
+    /// BYTE_ARRAY - 4 byte length stored as little endian, followed by bytes.
+    /// FIXED_LEN_BYTE_ARRAY - Just the bytes.
+    Plain,
+    /// Deprecated: Dictionary encoding. The values in the dictionary are encoded in the
+    /// plain type.
+    /// in a data page use RLE_DICTIONARY instead.
+    /// in a Dictionary page use PLAIN instead
+    PlainDictionary,
+    /// Group packed run length encoding. Usable for definition/repetition levels
+    /// encoding and Booleans (on one bit: 0 is false; 1 is true.)
+    Rle,
+    /// Bit packed encoding.  This can only be used if the data has a known max
+    /// width.  Usable for definition/repetition levels encoding.
+    BitPacked,
+    /// Delta encoding for integers. This can be used for int columns and works best
+    /// on sorted data
+    DeltaBinaryPacked,
+    /// Encoding for byte arrays to separate the length values and the data. The lengths
+    /// are encoded using DELTA_BINARY_PACKED
+    DeltaLengthByteArray,
+    /// Incremental-encoded byte array. Prefix lengths are encoded using DELTA_BINARY_PACKED.
+    /// Suffixes are stored as delta length byte arrays.
+    DeltaByteArray,
+    /// Dictionary encoding: the ids are encoded using the RLE encoding
+    RleDictionary,
+    /// Encoding for floating-point data.
+    /// K byte-streams are created where K is the size in bytes of the data type.
+    /// The individual bytes of an FP value are scattered to the corresponding stream and
+    /// the streams are concatenated.
+    /// This itself does not reduce the size of the data but can lead to better compression
+    /// afterwards.
+    ByteStreamSplit,
+}
+
+impl TryFrom<ParquetEncoding> for Encoding {
+    type Error = ParquetError;
+
+    fn try_from(encoding: ParquetEncoding) -> Result<Self, Self::Error> {
+        Ok(match encoding {
+            ParquetEncoding::PLAIN => Encoding::Plain,
+            ParquetEncoding::PLAIN_DICTIONARY => Encoding::PlainDictionary,
+            ParquetEncoding::RLE => Encoding::Rle,
+            ParquetEncoding::BIT_PACKED => Encoding::BitPacked,
+            ParquetEncoding::DELTA_BINARY_PACKED => Encoding::DeltaBinaryPacked,
+            ParquetEncoding::DELTA_LENGTH_BYTE_ARRAY => Encoding::DeltaLengthByteArray,
+            ParquetEncoding::DELTA_BYTE_ARRAY => Encoding::DeltaByteArray,
+            ParquetEncoding::RLE_DICTIONARY => Encoding::RleDictionary,
+            ParquetEncoding::BYTE_STREAM_SPLIT => Encoding::ByteStreamSplit,
+            _ => return Err(ParquetError::OutOfSpec("Thrift out of range".to_string())),
+        })
+    }
+}
+
+impl From<Encoding> for ParquetEncoding {
+    fn from(encoding: Encoding) -> Self {
+        match encoding {
+            Encoding::Plain => ParquetEncoding::PLAIN,
+            Encoding::PlainDictionary => ParquetEncoding::PLAIN_DICTIONARY,
+            Encoding::Rle => ParquetEncoding::RLE,
+            Encoding::BitPacked => ParquetEncoding::BIT_PACKED,
+            Encoding::DeltaBinaryPacked => ParquetEncoding::DELTA_BINARY_PACKED,
+            Encoding::DeltaLengthByteArray => ParquetEncoding::DELTA_LENGTH_BYTE_ARRAY,
+            Encoding::DeltaByteArray => ParquetEncoding::DELTA_BYTE_ARRAY,
+            Encoding::RleDictionary => ParquetEncoding::RLE_DICTIONARY,
+            Encoding::ByteStreamSplit => ParquetEncoding::BYTE_STREAM_SPLIT,
+        }
+    }
+}
+
+pub trait DataPageHeaderExt {
+    fn encoding(&self) -> Encoding;
+    fn repetition_level_encoding(&self) -> Encoding;
+    fn definition_level_encoding(&self) -> Encoding;
+}
+
+impl DataPageHeaderExt for DataPageHeader {
+    fn encoding(&self) -> Encoding {
+        self.encoding.try_into().unwrap()
+    }
+
+    fn repetition_level_encoding(&self) -> Encoding {
+        self.repetition_level_encoding.try_into().unwrap()
+    }
+
+    fn definition_level_encoding(&self) -> Encoding {
+        self.definition_level_encoding.try_into().unwrap()
+    }
+}
+
+impl DataPageHeaderExt for DataPageHeaderV2 {
+    fn encoding(&self) -> Encoding {
+        self.encoding.try_into().unwrap()
+    }
+
+    fn repetition_level_encoding(&self) -> Encoding {
+        Encoding::Rle
+    }
+
+    fn definition_level_encoding(&self) -> Encoding {
+        Encoding::Rle
+    }
+}

--- a/src/read/compression.rs
+++ b/src/read/compression.rs
@@ -1,4 +1,4 @@
-use parquet_format::DataPageHeaderV2;
+use parquet_format_async_temp::DataPageHeaderV2;
 
 use crate::compression::{create_codec, Codec};
 use crate::error::Result;

--- a/src/read/metadata.rs
+++ b/src/read/metadata.rs
@@ -32,7 +32,7 @@ use super::super::{metadata::*, DEFAULT_FOOTER_READ_SIZE, FOOTER_SIZE, PARQUET_M
 use crate::error::{ParquetError, Result};
 use crate::schema::types::ParquetType;
 
-fn metadata_len(buffer: &[u8], len: usize) -> i32 {
+pub(super) fn metadata_len(buffer: &[u8], len: usize) -> i32 {
     i32::from_le_bytes(buffer[len - 8..len - 4].try_into().unwrap())
 }
 
@@ -138,7 +138,7 @@ pub fn read_metadata<R: Read + Seek>(reader: &mut R) -> Result<FileMetaData> {
 
 /// Parses column orders from Thrift definition.
 /// If no column orders are defined, returns `None`.
-fn parse_column_orders(
+pub(super) fn parse_column_orders(
     orders: &[TColumnOrder],
     schema_descr: &SchemaDescriptor,
 ) -> Vec<ColumnOrder> {
@@ -229,7 +229,7 @@ mod tests {
                     basic_info,
                     ..
                 } => {
-                    assert_eq!(basic_info.repetition(), &FieldRepetitionType::Optional);
+                    assert_eq!(basic_info.repetition(), &FieldRepetitionType::OPTIONAL);
                     *physical_type
                 }
                 _ => {

--- a/src/read/metadata.rs
+++ b/src/read/metadata.rs
@@ -21,8 +21,8 @@ use std::{
     io::{Cursor, Read, Seek, SeekFrom},
 };
 
-use parquet_format::{ColumnOrder as TColumnOrder, FileMetaData as TFileMetaData};
-use thrift::protocol::TCompactInputProtocol;
+use parquet_format_async_temp::thrift::protocol::TCompactInputProtocol;
+use parquet_format_async_temp::{ColumnOrder as TColumnOrder, FileMetaData as TFileMetaData};
 
 use super::super::metadata::get_sort_order;
 use super::super::metadata::ColumnOrder;
@@ -174,7 +174,7 @@ pub(super) fn parse_column_orders(
 mod tests {
     use std::fs::File;
 
-    use parquet_format::FieldRepetitionType;
+    use parquet_format_async_temp::FieldRepetitionType;
 
     use super::*;
 

--- a/src/read/metadata.rs
+++ b/src/read/metadata.rs
@@ -174,11 +174,9 @@ pub(super) fn parse_column_orders(
 mod tests {
     use std::fs::File;
 
-    use parquet_format_async_temp::FieldRepetitionType;
-
     use super::*;
 
-    use crate::schema::types::PhysicalType;
+    use crate::schema::{types::PhysicalType, Repetition};
     use crate::tests::get_path;
 
     #[test]
@@ -229,7 +227,7 @@ mod tests {
                     basic_info,
                     ..
                 } => {
-                    assert_eq!(basic_info.repetition(), &FieldRepetitionType::OPTIONAL);
+                    assert_eq!(basic_info.repetition(), &Repetition::Optional);
                     *physical_type
                 }
                 _ => {

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -59,7 +59,7 @@ pub fn get_page_iterator<'a, RR: Read + Seek>(
     Ok(PageIterator::new(
         reader,
         column_metadata.num_values(),
-        *column_metadata.compression(),
+        column_metadata.compression(),
         column_metadata.descriptor().clone(),
         pages_filter,
         buffer,

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -2,6 +2,7 @@ mod compression;
 pub mod levels;
 mod metadata;
 mod page_iterator;
+mod stream;
 
 pub use streaming_iterator;
 pub use streaming_iterator::StreamingIterator;
@@ -9,6 +10,7 @@ pub use streaming_iterator::StreamingIterator;
 pub use compression::{decompress, Decompressor};
 
 pub use metadata::read_metadata;
+pub use stream::read_metadata as read_metadata_async;
 
 use std::io::{Read, Seek, SeekFrom};
 use std::sync::Arc;

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -2,6 +2,9 @@ mod compression;
 pub mod levels;
 mod metadata;
 mod page_iterator;
+#[cfg(feature = "stream")]
+mod page_stream;
+#[cfg(feature = "stream")]
 mod stream;
 
 pub use streaming_iterator;
@@ -10,6 +13,7 @@ pub use streaming_iterator::StreamingIterator;
 pub use compression::{decompress, Decompressor};
 
 pub use metadata::read_metadata;
+#[cfg(feature = "stream")]
 pub use stream::read_metadata as read_metadata_async;
 
 use std::io::{Read, Seek, SeekFrom};
@@ -19,6 +23,8 @@ use crate::metadata::RowGroupMetaData;
 use crate::{error::Result, metadata::FileMetaData};
 
 pub use page_iterator::{PageFilter, PageIterator};
+#[cfg(feature = "stream")]
+pub use page_stream::get_page_stream;
 
 /// Filters row group metadata to only those row groups,
 /// for which the predicate function returns true

--- a/src/read/page_iterator.rs
+++ b/src/read/page_iterator.rs
@@ -1,7 +1,7 @@
 use std::{io::Read, sync::Arc};
 
-use parquet_format::{CompressionCodec, PageType};
-use thrift::protocol::TCompactInputProtocol;
+use parquet_format_async_temp::thrift::protocol::TCompactInputProtocol;
+use parquet_format_async_temp::{CompressionCodec, PageType};
 
 use crate::error::Result;
 use crate::metadata::ColumnDescriptor;

--- a/src/read/page_iterator.rs
+++ b/src/read/page_iterator.rs
@@ -129,7 +129,7 @@ fn build_page<R: Read>(
     }
 
     match page_header.type_ {
-        PageType::DictionaryPage => {
+        PageType::DICTIONARY_PAGE => {
             let dict_header = page_header.dictionary_page_header.as_ref().unwrap();
             let is_sorted = dict_header.is_sorted.unwrap_or(false);
 
@@ -147,7 +147,7 @@ fn build_page<R: Read>(
             reader.current_dictionary = Some(page);
             Ok(None)
         }
-        PageType::DataPage => {
+        PageType::DATA_PAGE => {
             let header = page_header.data_page_header.unwrap();
             reader.seen_num_values += header.num_values as i64;
 
@@ -160,7 +160,7 @@ fn build_page<R: Read>(
                 reader.descriptor.clone(),
             )))
         }
-        PageType::DataPageV2 => {
+        PageType::DATA_PAGE_V2 => {
             let header = page_header.data_page_header_v2.unwrap();
             reader.seen_num_values += header.num_values as i64;
 
@@ -173,6 +173,6 @@ fn build_page<R: Read>(
                 reader.descriptor.clone(),
             )))
         }
-        PageType::IndexPage => Ok(None),
+        _ => Ok(None),
     }
 }

--- a/src/read/page_stream.rs
+++ b/src/read/page_stream.rs
@@ -1,0 +1,85 @@
+use std::io::SeekFrom;
+
+use async_stream::try_stream;
+use futures::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt, Stream};
+use parquet_format::CompressionCodec;
+use thrift::protocol::TCompactInputStreamProtocol;
+
+use crate::error::Result;
+use crate::metadata::{ColumnDescriptor, FileMetaData};
+
+use crate::page::{CompressedDataPage, ParquetPageHeader};
+
+use super::page_iterator::{finish_page, FinishedPage};
+
+/// Returns a stream of compressed data pages
+pub async fn get_page_stream<'a, RR: AsyncRead + Unpin + Send + AsyncSeek>(
+    metadata: &'a FileMetaData,
+    row_group: usize,
+    column: usize,
+    reader: &'a mut RR,
+    buffer: Vec<u8>,
+) -> Result<impl Stream<Item = Result<CompressedDataPage>> + 'a> {
+    let column_metadata = metadata.row_groups[row_group].column(column);
+    let (col_start, _) = column_metadata.byte_range();
+    reader.seek(SeekFrom::Start(col_start)).await?;
+    Ok(_get_page_stream(
+        reader,
+        column_metadata.num_values(),
+        *column_metadata.compression(),
+        column_metadata.descriptor(),
+        buffer,
+    ))
+}
+
+fn _get_page_stream<'a, R: AsyncRead + Unpin + Send>(
+    reader: &'a mut R,
+    total_num_values: i64,
+    compression: CompressionCodec,
+    descriptor: &'a ColumnDescriptor,
+    mut buffer: Vec<u8>,
+) -> impl Stream<Item = Result<CompressedDataPage>> + 'a {
+    let mut seen_values = 0i64;
+    let mut current_dictionary = None;
+    try_stream! {
+        while seen_values < total_num_values {
+            // the header
+            let page_header = read_page_header(reader).await?;
+
+            // followed by the buffer
+            let read_size = page_header.compressed_page_size as usize;
+            if read_size > 0 {
+                buffer.resize(read_size, 0);
+                reader.read_exact(&mut buffer).await?;
+            }
+            let result = finish_page(
+                page_header,
+                &mut buffer,
+                compression,
+                &current_dictionary,
+                descriptor,
+            )?;
+
+            match result {
+                FinishedPage::Data(page, new_seen_values) => {
+                    seen_values += new_seen_values;
+                    yield page
+                }
+                FinishedPage::Dict(dict) => {
+                    current_dictionary = Some(dict);
+                    continue
+                }
+                _ => continue,
+            }
+        }
+    }
+}
+
+/// Reads Page header from Thrift.
+async fn read_page_header<R: AsyncRead + Unpin + Send>(
+    reader: &mut R,
+) -> Result<ParquetPageHeader> {
+    let mut prot = TCompactInputStreamProtocol::new(reader);
+    let page_header = ParquetPageHeader::stream_from_in_protocol(&mut prot).await?;
+    Ok(page_header)
+}

--- a/src/read/page_stream.rs
+++ b/src/read/page_stream.rs
@@ -2,8 +2,8 @@ use std::io::SeekFrom;
 
 use async_stream::try_stream;
 use futures::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt, Stream};
-use parquet_format::CompressionCodec;
-use thrift::protocol::TCompactInputStreamProtocol;
+use parquet_format_async_temp::thrift::protocol::TCompactInputStreamProtocol;
+use parquet_format_async_temp::CompressionCodec;
 
 use crate::error::Result;
 use crate::metadata::{ColumnDescriptor, FileMetaData};

--- a/src/read/page_stream.rs
+++ b/src/read/page_stream.rs
@@ -3,11 +3,10 @@ use std::io::SeekFrom;
 use async_stream::try_stream;
 use futures::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt, Stream};
 use parquet_format_async_temp::thrift::protocol::TCompactInputStreamProtocol;
-use parquet_format_async_temp::CompressionCodec;
 
+use crate::compression::Compression;
 use crate::error::Result;
 use crate::metadata::{ColumnDescriptor, FileMetaData};
-
 use crate::page::{CompressedDataPage, ParquetPageHeader};
 
 use super::page_iterator::{finish_page, FinishedPage};
@@ -26,7 +25,7 @@ pub async fn get_page_stream<'a, RR: AsyncRead + Unpin + Send + AsyncSeek>(
     Ok(_get_page_stream(
         reader,
         column_metadata.num_values(),
-        *column_metadata.compression(),
+        column_metadata.compression(),
         column_metadata.descriptor(),
         buffer,
     ))
@@ -35,7 +34,7 @@ pub async fn get_page_stream<'a, RR: AsyncRead + Unpin + Send + AsyncSeek>(
 fn _get_page_stream<'a, R: AsyncRead + Unpin + Send>(
     reader: &'a mut R,
     total_num_values: i64,
-    compression: CompressionCodec,
+    compression: Compression,
     descriptor: &'a ColumnDescriptor,
     mut buffer: Vec<u8>,
 ) -> impl Stream<Item = Result<CompressedDataPage>> + 'a {

--- a/src/read/stream.rs
+++ b/src/read/stream.rs
@@ -1,0 +1,108 @@
+use std::io::SeekFrom;
+
+use futures::{io::Cursor, AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt};
+use parquet_format::FileMetaData as TFileMetaData;
+use thrift::protocol::TCompactInputStreamProtocol;
+
+use super::super::{metadata::*, DEFAULT_FOOTER_READ_SIZE, FOOTER_SIZE, PARQUET_MAGIC};
+use super::metadata::{metadata_len, parse_column_orders};
+use crate::error::{ParquetError, Result};
+
+async fn stream_len(
+    seek: &mut (impl AsyncSeek + std::marker::Unpin),
+) -> std::result::Result<u64, std::io::Error> {
+    let old_pos = seek.seek(SeekFrom::Current(0)).await?;
+    let len = seek.seek(SeekFrom::End(0)).await?;
+
+    // Avoid seeking a third time when we were already at the end of the
+    // stream. The branch is usually way cheaper than a seek operation.
+    if old_pos != len {
+        seek.seek(SeekFrom::Start(old_pos)).await?;
+    }
+
+    Ok(len)
+}
+
+pub async fn read_metadata<R: AsyncRead + AsyncSeek + Send + std::marker::Unpin>(
+    reader: &mut R,
+) -> Result<FileMetaData> {
+    // check file is large enough to hold footer
+    let file_size = stream_len(reader).await?;
+    if file_size < FOOTER_SIZE {
+        return Err(general_err!(
+            "Invalid Parquet file. Size is smaller than footer"
+        ));
+    }
+
+    // read and cache up to DEFAULT_FOOTER_READ_SIZE bytes from the end and process the footer
+    let default_end_len = std::cmp::min(DEFAULT_FOOTER_READ_SIZE, file_size) as usize;
+    reader
+        .seek(SeekFrom::End(-(default_end_len as i64)))
+        .await?;
+    let mut default_len_end_buf = vec![0; default_end_len];
+    reader.read_exact(&mut default_len_end_buf).await?;
+
+    // check this is indeed a parquet file
+    if default_len_end_buf[default_end_len - 4..] != PARQUET_MAGIC {
+        return Err(general_err!("Invalid Parquet file. Corrupt footer"));
+    }
+
+    let metadata_len = metadata_len(&default_len_end_buf, default_end_len);
+
+    if metadata_len < 0 {
+        return Err(general_err!(
+            "Invalid Parquet file. Metadata length is less than zero ({})",
+            metadata_len
+        ));
+    }
+    let footer_metadata_len = FOOTER_SIZE + metadata_len as u64;
+
+    let t_file_metadata = if footer_metadata_len > file_size {
+        return Err(general_err!(
+            "Invalid Parquet file. Metadata start is less than zero ({})",
+            file_size as i64 - footer_metadata_len as i64
+        ));
+    } else if footer_metadata_len < DEFAULT_FOOTER_READ_SIZE {
+        // the whole metadata is in the bytes we already read
+        // build up the reader covering the entire metadata
+        let mut reader = Cursor::new(default_len_end_buf);
+        reader
+            .seek(SeekFrom::End(-(footer_metadata_len as i64)))
+            .await?;
+
+        let mut prot = TCompactInputStreamProtocol::new(reader);
+        TFileMetaData::stream_from_in_protocol(&mut prot).await?
+    } else {
+        // the end of file read by default is not long enough, read again including all metadata.
+        reader
+            .seek(SeekFrom::End(-(footer_metadata_len as i64)))
+            .await?;
+
+        let mut prot = TCompactInputStreamProtocol::new(reader);
+        TFileMetaData::stream_from_in_protocol(&mut prot).await?
+    };
+
+    let schema = t_file_metadata.schema.iter().collect::<Vec<_>>();
+    let schema_descr = SchemaDescriptor::try_from_thrift(&schema)?;
+
+    let row_groups = t_file_metadata
+        .row_groups
+        .into_iter()
+        .map(|rg| RowGroupMetaData::try_from_thrift(&schema_descr, rg))
+        .collect::<Result<Vec<_>>>()?;
+
+    // compute and cache column orders
+    let column_orders = t_file_metadata
+        .column_orders
+        .map(|orders| parse_column_orders(&orders, &schema_descr));
+
+    Ok(FileMetaData::new(
+        t_file_metadata.version,
+        t_file_metadata.num_rows,
+        t_file_metadata.created_by,
+        row_groups,
+        t_file_metadata.key_value_metadata,
+        schema_descr,
+        column_orders,
+    ))
+}

--- a/src/read/stream.rs
+++ b/src/read/stream.rs
@@ -1,8 +1,8 @@
 use std::io::SeekFrom;
 
 use futures::{io::Cursor, AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt};
-use parquet_format::FileMetaData as TFileMetaData;
-use thrift::protocol::TCompactInputStreamProtocol;
+use parquet_format_async_temp::thrift::protocol::TCompactInputStreamProtocol;
+use parquet_format_async_temp::FileMetaData as TFileMetaData;
 
 use super::super::{metadata::*, DEFAULT_FOOTER_READ_SIZE, FOOTER_SIZE, PARQUET_MAGIC};
 use super::metadata::{metadata_len, parse_column_orders};

--- a/src/schema/io_message/from_message.rs
+++ b/src/schema/io_message/from_message.rs
@@ -49,7 +49,7 @@ use super::super::types::{
 use super::super::*;
 use crate::error::{ParquetError, Result};
 
-use parquet_format_async_temp::ConvertedType;
+use parquet_format_async_temp::*;
 
 fn is_logical_type(s: &str) -> bool {
     matches!(
@@ -151,9 +151,9 @@ fn converted_primitive_from_str(s: &str) -> Option<ConvertedType> {
 
 fn repetition_from_str(s: &str) -> Result<Repetition> {
     Ok(match s {
-        "REQUIRED" => Repetition::REQUIRED,
-        "OPTIONAL" => Repetition::OPTIONAL,
-        "REPEATED" => Repetition::REPEATED,
+        "REQUIRED" => Repetition::Required,
+        "OPTIONAL" => Repetition::Optional,
+        "REPEATED" => Repetition::Repeated,
         other => return Err(general_err!("Invalid repetition {}", other)),
     })
 }
@@ -453,7 +453,9 @@ impl<'a> Parser<'a> {
 
             // converted type decimal
             let (converted_type, maybe_decimal) = match converted_type {
-                Some(parquet_format_async_temp::ConvertedType::DECIMAL) => self.parse_converted_decimal()?,
+                Some(parquet_format_async_temp::ConvertedType::DECIMAL) => {
+                    self.parse_converted_decimal()?
+                }
                 other => (other, None),
             };
             let converted_type = converted_type
@@ -891,7 +893,7 @@ mod tests {
             ParquetType::try_from_primitive(
                 "f1".to_string(),
                 PhysicalType::FixedLenByteArray(5),
-                Repetition::OPTIONAL,
+                Repetition::Optional,
                 None,
                 Some(LogicalType::DECIMAL(DecimalType {
                     precision: 9,
@@ -902,7 +904,7 @@ mod tests {
             ParquetType::try_from_primitive(
                 "f2".to_string(),
                 PhysicalType::FixedLenByteArray(16),
-                Repetition::OPTIONAL,
+                Repetition::Optional,
                 None,
                 Some(LogicalType::DECIMAL(DecimalType {
                     precision: 38,
@@ -946,7 +948,7 @@ mod tests {
         let a2 = ParquetType::try_from_primitive(
             "a2".to_string(),
             PhysicalType::ByteArray,
-            Repetition::REPEATED,
+            Repetition::Repeated,
             Some(PrimitiveConvertedType::Utf8),
             None,
             None,
@@ -964,7 +966,7 @@ mod tests {
                 ParquetType::from_physical("b3".to_string(), PhysicalType::Int32),
                 ParquetType::from_physical("b4".to_string(), PhysicalType::Double),
             ],
-            Some(Repetition::REPEATED),
+            Some(Repetition::Repeated),
             None,
             None,
         );
@@ -978,7 +980,7 @@ mod tests {
         let a0 = ParquetType::from_converted(
             "a0".to_string(),
             vec![a1, b1],
-            Some(Repetition::REQUIRED),
+            Some(Repetition::Required),
             None,
             None,
         );
@@ -1011,7 +1013,7 @@ mod tests {
         let f1 = ParquetType::try_from_primitive(
             "_1".to_string(),
             PhysicalType::Int32,
-            Repetition::REQUIRED,
+            Repetition::Required,
             Some(PrimitiveConvertedType::Int8),
             None,
             None,
@@ -1019,7 +1021,7 @@ mod tests {
         let f2 = ParquetType::try_from_primitive(
             "_2".to_string(),
             PhysicalType::Int32,
-            Repetition::REQUIRED,
+            Repetition::Required,
             Some(PrimitiveConvertedType::Int16),
             None,
             None,
@@ -1027,7 +1029,7 @@ mod tests {
         let f3 = ParquetType::try_from_primitive(
             "_3".to_string(),
             PhysicalType::Float,
-            Repetition::REQUIRED,
+            Repetition::Required,
             None,
             None,
             None,
@@ -1035,7 +1037,7 @@ mod tests {
         let f4 = ParquetType::try_from_primitive(
             "_4".to_string(),
             PhysicalType::Double,
-            Repetition::REQUIRED,
+            Repetition::Required,
             None,
             None,
             None,
@@ -1043,7 +1045,7 @@ mod tests {
         let f5 = ParquetType::try_from_primitive(
             "_5".to_string(),
             PhysicalType::Int32,
-            Repetition::OPTIONAL,
+            Repetition::Optional,
             None,
             Some(LogicalType::DATE(Default::default())),
             None,
@@ -1051,7 +1053,7 @@ mod tests {
         let f6 = ParquetType::try_from_primitive(
             "_6".to_string(),
             PhysicalType::ByteArray,
-            Repetition::OPTIONAL,
+            Repetition::Optional,
             Some(PrimitiveConvertedType::Utf8),
             None,
             None,
@@ -1089,7 +1091,7 @@ mod tests {
         let f1 = ParquetType::try_from_primitive(
             "_1".to_string(),
             PhysicalType::Int32,
-            Repetition::REQUIRED,
+            Repetition::Required,
             None,
             Some(LogicalType::INTEGER(IntType {
                 bit_width: 8,
@@ -1100,7 +1102,7 @@ mod tests {
         let f2 = ParquetType::try_from_primitive(
             "_2".to_string(),
             PhysicalType::Int32,
-            Repetition::REQUIRED,
+            Repetition::Required,
             None,
             Some(LogicalType::INTEGER(IntType {
                 bit_width: 16,
@@ -1111,7 +1113,7 @@ mod tests {
         let f3 = ParquetType::try_from_primitive(
             "_3".to_string(),
             PhysicalType::Float,
-            Repetition::REQUIRED,
+            Repetition::Required,
             None,
             None,
             None,
@@ -1119,7 +1121,7 @@ mod tests {
         let f4 = ParquetType::try_from_primitive(
             "_4".to_string(),
             PhysicalType::Double,
-            Repetition::REQUIRED,
+            Repetition::Required,
             None,
             None,
             None,
@@ -1127,7 +1129,7 @@ mod tests {
         let f5 = ParquetType::try_from_primitive(
             "_5".to_string(),
             PhysicalType::Int32,
-            Repetition::OPTIONAL,
+            Repetition::Optional,
             None,
             Some(LogicalType::DATE(Default::default())),
             None,
@@ -1135,7 +1137,7 @@ mod tests {
         let f6 = ParquetType::try_from_primitive(
             "_6".to_string(),
             PhysicalType::Int32,
-            Repetition::OPTIONAL,
+            Repetition::Optional,
             None,
             Some(LogicalType::TIME(TimeType {
                 is_adjusted_to_u_t_c: false,
@@ -1146,7 +1148,7 @@ mod tests {
         let f7 = ParquetType::try_from_primitive(
             "_7".to_string(),
             PhysicalType::Int64,
-            Repetition::OPTIONAL,
+            Repetition::Optional,
             None,
             Some(LogicalType::TIME(TimeType {
                 is_adjusted_to_u_t_c: true,
@@ -1157,7 +1159,7 @@ mod tests {
         let f8 = ParquetType::try_from_primitive(
             "_8".to_string(),
             PhysicalType::Int64,
-            Repetition::OPTIONAL,
+            Repetition::Optional,
             None,
             Some(LogicalType::TIMESTAMP(TimestampType {
                 is_adjusted_to_u_t_c: true,
@@ -1168,7 +1170,7 @@ mod tests {
         let f9 = ParquetType::try_from_primitive(
             "_9".to_string(),
             PhysicalType::Int64,
-            Repetition::OPTIONAL,
+            Repetition::Optional,
             None,
             Some(LogicalType::TIMESTAMP(TimestampType {
                 is_adjusted_to_u_t_c: false,
@@ -1180,7 +1182,7 @@ mod tests {
         let f10 = ParquetType::try_from_primitive(
             "_10".to_string(),
             PhysicalType::ByteArray,
-            Repetition::OPTIONAL,
+            Repetition::Optional,
             None,
             Some(LogicalType::STRING(Default::default())),
             None,

--- a/src/schema/io_message/from_message.rs
+++ b/src/schema/io_message/from_message.rs
@@ -946,7 +946,7 @@ mod tests {
         let a2 = ParquetType::try_from_primitive(
             "a2".to_string(),
             PhysicalType::ByteArray,
-            Repetition::Repeated,
+            Repetition::REPEATED,
             Some(PrimitiveConvertedType::Utf8),
             None,
             None,
@@ -964,7 +964,7 @@ mod tests {
                 ParquetType::from_physical("b3".to_string(), PhysicalType::Int32),
                 ParquetType::from_physical("b4".to_string(), PhysicalType::Double),
             ],
-            Some(Repetition::Repeated),
+            Some(Repetition::REPEATED),
             None,
             None,
         );
@@ -978,7 +978,7 @@ mod tests {
         let a0 = ParquetType::from_converted(
             "a0".to_string(),
             vec![a1, b1],
-            Some(Repetition::Required),
+            Some(Repetition::REQUIRED),
             None,
             None,
         );
@@ -1011,7 +1011,7 @@ mod tests {
         let f1 = ParquetType::try_from_primitive(
             "_1".to_string(),
             PhysicalType::Int32,
-            Repetition::Required,
+            Repetition::REQUIRED,
             Some(PrimitiveConvertedType::Int8),
             None,
             None,
@@ -1019,7 +1019,7 @@ mod tests {
         let f2 = ParquetType::try_from_primitive(
             "_2".to_string(),
             PhysicalType::Int32,
-            Repetition::Required,
+            Repetition::REQUIRED,
             Some(PrimitiveConvertedType::Int16),
             None,
             None,
@@ -1027,7 +1027,7 @@ mod tests {
         let f3 = ParquetType::try_from_primitive(
             "_3".to_string(),
             PhysicalType::Float,
-            Repetition::Required,
+            Repetition::REQUIRED,
             None,
             None,
             None,
@@ -1035,7 +1035,7 @@ mod tests {
         let f4 = ParquetType::try_from_primitive(
             "_4".to_string(),
             PhysicalType::Double,
-            Repetition::Required,
+            Repetition::REQUIRED,
             None,
             None,
             None,
@@ -1089,7 +1089,7 @@ mod tests {
         let f1 = ParquetType::try_from_primitive(
             "_1".to_string(),
             PhysicalType::Int32,
-            Repetition::Required,
+            Repetition::REQUIRED,
             None,
             Some(LogicalType::INTEGER(IntType {
                 bit_width: 8,
@@ -1100,7 +1100,7 @@ mod tests {
         let f2 = ParquetType::try_from_primitive(
             "_2".to_string(),
             PhysicalType::Int32,
-            Repetition::Required,
+            Repetition::REQUIRED,
             None,
             Some(LogicalType::INTEGER(IntType {
                 bit_width: 16,
@@ -1111,7 +1111,7 @@ mod tests {
         let f3 = ParquetType::try_from_primitive(
             "_3".to_string(),
             PhysicalType::Float,
-            Repetition::Required,
+            Repetition::REQUIRED,
             None,
             None,
             None,
@@ -1119,7 +1119,7 @@ mod tests {
         let f4 = ParquetType::try_from_primitive(
             "_4".to_string(),
             PhysicalType::Double,
-            Repetition::Required,
+            Repetition::REQUIRED,
             None,
             None,
             None,

--- a/src/schema/io_message/from_message.rs
+++ b/src/schema/io_message/from_message.rs
@@ -49,7 +49,7 @@ use super::super::types::{
 use super::super::*;
 use crate::error::{ParquetError, Result};
 
-use parquet_format::ConvertedType;
+use parquet_format_async_temp::ConvertedType;
 
 fn is_logical_type(s: &str) -> bool {
     matches!(
@@ -453,7 +453,7 @@ impl<'a> Parser<'a> {
 
             // converted type decimal
             let (converted_type, maybe_decimal) = match converted_type {
-                Some(parquet_format::ConvertedType::DECIMAL) => self.parse_converted_decimal()?,
+                Some(parquet_format_async_temp::ConvertedType::DECIMAL) => self.parse_converted_decimal()?,
                 other => (other, None),
             };
             let converted_type = converted_type
@@ -512,7 +512,7 @@ impl<'a> Parser<'a> {
 
         assert_token(self.tokenizer.next(), ")")?;
         Ok((
-            Some(parquet_format::ConvertedType::DECIMAL),
+            Some(parquet_format_async_temp::ConvertedType::DECIMAL),
             Some((precision, scale)),
         ))
     }

--- a/src/schema/io_thrift/from_thrift.rs
+++ b/src/schema/io_thrift/from_thrift.rs
@@ -1,4 +1,4 @@
-use parquet_format::SchemaElement;
+use parquet_format_async_temp::SchemaElement;
 
 use crate::error::{ParquetError, Result};
 

--- a/src/schema/io_thrift/to_thrift.rs
+++ b/src/schema/io_thrift/to_thrift.rs
@@ -40,7 +40,7 @@ fn to_thrift_helper(schema: &ParquetType, elements: &mut Vec<SchemaElement>) {
             let element = SchemaElement {
                 type_: Some(type_),
                 type_length,
-                repetition_type: Some(*basic_info.repetition()),
+                repetition_type: Some((*basic_info.repetition()).into()),
                 name: basic_info.name().to_owned(),
                 num_children: None,
                 converted_type,
@@ -72,7 +72,7 @@ fn to_thrift_helper(schema: &ParquetType, elements: &mut Vec<SchemaElement>) {
             let element = SchemaElement {
                 type_: None,
                 type_length: None,
-                repetition_type,
+                repetition_type: repetition_type.map(|x| x.into()),
                 name: basic_info.name().to_owned(),
                 num_children: Some(fields.len() as i32),
                 converted_type,

--- a/src/schema/io_thrift/to_thrift.rs
+++ b/src/schema/io_thrift/to_thrift.rs
@@ -1,4 +1,4 @@
-use parquet_format::SchemaElement;
+use parquet_format_async_temp::SchemaElement;
 
 use crate::error::{ParquetError, Result};
 

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -1,11 +1,8 @@
-pub use parquet_format_async_temp::FieldRepetitionType as Repetition;
 pub use parquet_format_async_temp::SchemaElement;
 
-pub use parquet_format_async_temp::*;
+pub use crate::parquet_bridge::Repetition;
 
 pub mod io_message;
 pub mod io_thrift;
 
-//pub mod printer;
 pub mod types;
-//pub mod visitor;

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -1,7 +1,7 @@
-pub use parquet_format::FieldRepetitionType as Repetition;
-pub use parquet_format::SchemaElement;
+pub use parquet_format_async_temp::FieldRepetitionType as Repetition;
+pub use parquet_format_async_temp::SchemaElement;
 
-pub use parquet_format::*;
+pub use parquet_format_async_temp::*;
 
 pub mod io_message;
 pub mod io_thrift;

--- a/src/schema/types/basic_type.rs
+++ b/src/schema/types/basic_type.rs
@@ -1,4 +1,4 @@
-use super::Repetition;
+use super::super::Repetition;
 
 /// Common type information.
 #[derive(Clone, Debug, PartialEq)]

--- a/src/schema/types/converted_type.rs
+++ b/src/schema/types/converted_type.rs
@@ -105,31 +105,31 @@ pub fn converted_to_primitive_converted(
 ) -> Result<PrimitiveConvertedType> {
     use PrimitiveConvertedType::*;
     Ok(match ty {
-        ConvertedType::Utf8 => Utf8,
-        ConvertedType::Enum => Enum,
-        ConvertedType::Decimal => {
+        &ConvertedType::UTF8 => Utf8,
+        &ConvertedType::ENUM => Enum,
+        &ConvertedType::DECIMAL => {
             if let Some(maybe_decimal) = maybe_decimal {
                 Decimal(maybe_decimal.0, maybe_decimal.1)
             } else {
                 return Err(general_err!("Decimal requires a precision and scale"));
             }
         }
-        ConvertedType::Date => Date,
-        ConvertedType::TimeMillis => TimeMillis,
-        ConvertedType::TimeMicros => TimeMicros,
-        ConvertedType::TimestampMillis => TimestampMillis,
-        ConvertedType::TimestampMicros => TimestampMicros,
-        ConvertedType::Uint8 => Uint8,
-        ConvertedType::Uint16 => Uint16,
-        ConvertedType::Uint32 => Uint32,
-        ConvertedType::Uint64 => Uint64,
-        ConvertedType::Int8 => Int8,
-        ConvertedType::Int16 => Int16,
-        ConvertedType::Int32 => Int32,
-        ConvertedType::Int64 => Int64,
-        ConvertedType::Json => Json,
-        ConvertedType::Bson => Bson,
-        ConvertedType::Interval => Interval,
+        &ConvertedType::DATE => Date,
+        &ConvertedType::TIME_MILLIS => TimeMillis,
+        &ConvertedType::TIME_MICROS => TimeMicros,
+        &ConvertedType::TIMESTAMP_MILLIS => TimestampMillis,
+        &ConvertedType::TIMESTAMP_MICROS => TimestampMicros,
+        &ConvertedType::UINT_8 => Uint8,
+        &ConvertedType::UINT_16 => Uint16,
+        &ConvertedType::UINT_32 => Uint32,
+        &ConvertedType::UINT_64 => Uint64,
+        &ConvertedType::INT_8 => Int8,
+        &ConvertedType::INT_16 => Int16,
+        &ConvertedType::INT_32 => Int32,
+        &ConvertedType::INT_64 => Int64,
+        &ConvertedType::JSON => Json,
+        &ConvertedType::BSON => Bson,
+        &ConvertedType::INTERVAL => Interval,
         _ => {
             return Err(general_err!(
                 "Converted type \"{:?}\" cannot be applied to a primitive type",
@@ -142,9 +142,9 @@ pub fn converted_to_primitive_converted(
 pub fn converted_to_group_converted(ty: &ConvertedType) -> Result<GroupConvertedType> {
     use GroupConvertedType::*;
     Ok(match ty {
-        ConvertedType::Map => Map,
-        ConvertedType::List => List,
-        ConvertedType::MapKeyValue => MapKeyValue,
+        &ConvertedType::MAP => Map,
+        &ConvertedType::LIST => List,
+        &ConvertedType::MAP_KEY_VALUE => MapKeyValue,
         _ => {
             return Err(general_err!(
                 "Converted type \"{:?}\" cannot be applied to a primitive type",
@@ -159,33 +159,33 @@ pub fn primitive_converted_to_converted(
 ) -> (ConvertedType, Option<(i32, i32)>) {
     use PrimitiveConvertedType::*;
     match ty {
-        Utf8 => (ConvertedType::Utf8, None),
-        Enum => (ConvertedType::Enum, None),
-        Decimal(precision, scale) => (ConvertedType::Decimal, Some((*precision, *scale))),
-        Date => (ConvertedType::Date, None),
-        TimeMillis => (ConvertedType::TimeMillis, None),
-        TimeMicros => (ConvertedType::TimeMicros, None),
-        TimestampMillis => (ConvertedType::TimestampMillis, None),
-        TimestampMicros => (ConvertedType::TimestampMicros, None),
-        Uint8 => (ConvertedType::Uint8, None),
-        Uint16 => (ConvertedType::Uint16, None),
-        Uint32 => (ConvertedType::Uint32, None),
-        Uint64 => (ConvertedType::Uint64, None),
-        Int8 => (ConvertedType::Int8, None),
-        Int16 => (ConvertedType::Int16, None),
-        Int32 => (ConvertedType::Int32, None),
-        Int64 => (ConvertedType::Int64, None),
-        Json => (ConvertedType::Json, None),
-        Bson => (ConvertedType::Bson, None),
-        Interval => (ConvertedType::Interval, None),
+        Utf8 => (ConvertedType::UTF8, None),
+        Enum => (ConvertedType::ENUM, None),
+        Decimal(precision, scale) => (ConvertedType::DECIMAL, Some((*precision, *scale))),
+        Date => (ConvertedType::DATE, None),
+        TimeMillis => (ConvertedType::TIME_MILLIS, None),
+        TimeMicros => (ConvertedType::TIME_MICROS, None),
+        TimestampMillis => (ConvertedType::TIMESTAMP_MILLIS, None),
+        TimestampMicros => (ConvertedType::TIMESTAMP_MICROS, None),
+        Uint8 => (ConvertedType::UINT_8, None),
+        Uint16 => (ConvertedType::UINT_16, None),
+        Uint32 => (ConvertedType::UINT_32, None),
+        Uint64 => (ConvertedType::UINT_64, None),
+        Int8 => (ConvertedType::INT_8, None),
+        Int16 => (ConvertedType::INT_16, None),
+        Int32 => (ConvertedType::INT_32, None),
+        Int64 => (ConvertedType::INT_64, None),
+        Json => (ConvertedType::JSON, None),
+        Bson => (ConvertedType::BSON, None),
+        Interval => (ConvertedType::INTERVAL, None),
     }
 }
 
 pub fn group_converted_converted_to(ty: &GroupConvertedType) -> ConvertedType {
     use GroupConvertedType::*;
     match ty {
-        Map => ConvertedType::Map,
-        List => ConvertedType::List,
-        MapKeyValue => ConvertedType::MapKeyValue,
+        Map => ConvertedType::MAP,
+        List => ConvertedType::LIST,
+        MapKeyValue => ConvertedType::MAP_KEY_VALUE,
     }
 }

--- a/src/schema/types/converted_type.rs
+++ b/src/schema/types/converted_type.rs
@@ -1,5 +1,5 @@
 use crate::error::{ParquetError, Result};
-use parquet_format::ConvertedType;
+use parquet_format_async_temp::ConvertedType;
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum PrimitiveConvertedType {

--- a/src/schema/types/converted_type.rs
+++ b/src/schema/types/converted_type.rs
@@ -104,32 +104,32 @@ pub fn converted_to_primitive_converted(
     maybe_decimal: Option<(i32, i32)>,
 ) -> Result<PrimitiveConvertedType> {
     use PrimitiveConvertedType::*;
-    Ok(match ty {
-        &ConvertedType::UTF8 => Utf8,
-        &ConvertedType::ENUM => Enum,
-        &ConvertedType::DECIMAL => {
+    Ok(match *ty {
+        ConvertedType::UTF8 => Utf8,
+        ConvertedType::ENUM => Enum,
+        ConvertedType::DECIMAL => {
             if let Some(maybe_decimal) = maybe_decimal {
                 Decimal(maybe_decimal.0, maybe_decimal.1)
             } else {
                 return Err(general_err!("Decimal requires a precision and scale"));
             }
         }
-        &ConvertedType::DATE => Date,
-        &ConvertedType::TIME_MILLIS => TimeMillis,
-        &ConvertedType::TIME_MICROS => TimeMicros,
-        &ConvertedType::TIMESTAMP_MILLIS => TimestampMillis,
-        &ConvertedType::TIMESTAMP_MICROS => TimestampMicros,
-        &ConvertedType::UINT_8 => Uint8,
-        &ConvertedType::UINT_16 => Uint16,
-        &ConvertedType::UINT_32 => Uint32,
-        &ConvertedType::UINT_64 => Uint64,
-        &ConvertedType::INT_8 => Int8,
-        &ConvertedType::INT_16 => Int16,
-        &ConvertedType::INT_32 => Int32,
-        &ConvertedType::INT_64 => Int64,
-        &ConvertedType::JSON => Json,
-        &ConvertedType::BSON => Bson,
-        &ConvertedType::INTERVAL => Interval,
+        ConvertedType::DATE => Date,
+        ConvertedType::TIME_MILLIS => TimeMillis,
+        ConvertedType::TIME_MICROS => TimeMicros,
+        ConvertedType::TIMESTAMP_MILLIS => TimestampMillis,
+        ConvertedType::TIMESTAMP_MICROS => TimestampMicros,
+        ConvertedType::UINT_8 => Uint8,
+        ConvertedType::UINT_16 => Uint16,
+        ConvertedType::UINT_32 => Uint32,
+        ConvertedType::UINT_64 => Uint64,
+        ConvertedType::INT_8 => Int8,
+        ConvertedType::INT_16 => Int16,
+        ConvertedType::INT_32 => Int32,
+        ConvertedType::INT_64 => Int64,
+        ConvertedType::JSON => Json,
+        ConvertedType::BSON => Bson,
+        ConvertedType::INTERVAL => Interval,
         _ => {
             return Err(general_err!(
                 "Converted type \"{:?}\" cannot be applied to a primitive type",
@@ -141,10 +141,10 @@ pub fn converted_to_primitive_converted(
 
 pub fn converted_to_group_converted(ty: &ConvertedType) -> Result<GroupConvertedType> {
     use GroupConvertedType::*;
-    Ok(match ty {
-        &ConvertedType::MAP => Map,
-        &ConvertedType::LIST => List,
-        &ConvertedType::MAP_KEY_VALUE => MapKeyValue,
+    Ok(match *ty {
+        ConvertedType::MAP => Map,
+        ConvertedType::LIST => List,
+        ConvertedType::MAP_KEY_VALUE => MapKeyValue,
         _ => {
             return Err(general_err!(
                 "Converted type \"{:?}\" cannot be applied to a primitive type",

--- a/src/schema/types/mod.rs
+++ b/src/schema/types/mod.rs
@@ -1,5 +1,7 @@
-pub use parquet_format_async_temp::FieldRepetitionType as Repetition;
-pub use parquet_format_async_temp::{LogicalType, TimeType, TimeUnit, Type};
+//pub use parquet_format_async_temp::FieldRepetitionType as Repetition;
+pub use parquet_format_async_temp::{
+    DecimalType, IntType, LogicalType, TimeType, TimeUnit, TimestampType, Type,
+};
 
 mod spec;
 

--- a/src/schema/types/mod.rs
+++ b/src/schema/types/mod.rs
@@ -1,5 +1,5 @@
-pub use parquet_format::FieldRepetitionType as Repetition;
-pub use parquet_format::{LogicalType, TimeType, TimeUnit, Type};
+pub use parquet_format_async_temp::FieldRepetitionType as Repetition;
+pub use parquet_format_async_temp::{LogicalType, TimeType, TimeUnit, Type};
 
 mod spec;
 

--- a/src/schema/types/parquet_type.rs
+++ b/src/schema/types/parquet_type.rs
@@ -97,7 +97,7 @@ impl ParquetType {
 /// Constructors
 impl ParquetType {
     pub fn new_root(name: String, fields: Vec<ParquetType>) -> Self {
-        let basic_info = BasicTypeInfo::new(name, Repetition::Optional, None, true);
+        let basic_info = BasicTypeInfo::new(name, Repetition::OPTIONAL, None, true);
         ParquetType::GroupType {
             basic_info,
             fields,
@@ -114,7 +114,7 @@ impl ParquetType {
         id: Option<i32>,
     ) -> Self {
         let basic_info =
-            BasicTypeInfo::new(name, repetition.unwrap_or(Repetition::Optional), id, false);
+            BasicTypeInfo::new(name, repetition.unwrap_or(Repetition::OPTIONAL), id, false);
         ParquetType::GroupType {
             basic_info,
             fields,
@@ -145,7 +145,7 @@ impl ParquetType {
     }
 
     pub fn from_physical(name: String, physical_type: PhysicalType) -> Self {
-        let basic_info = BasicTypeInfo::new(name, Repetition::Optional, None, false);
+        let basic_info = BasicTypeInfo::new(name, Repetition::OPTIONAL, None, false);
         ParquetType::PrimitiveType {
             basic_info,
             converted_type: None,

--- a/src/schema/types/parquet_type.rs
+++ b/src/schema/types/parquet_type.rs
@@ -2,9 +2,9 @@
 use crate::error::Result;
 use std::collections::HashMap;
 
+use super::super::Repetition;
 use super::{
     spec, BasicTypeInfo, GroupConvertedType, LogicalType, PhysicalType, PrimitiveConvertedType,
-    Repetition,
 };
 
 /// Representation of a Parquet type.
@@ -97,7 +97,7 @@ impl ParquetType {
 /// Constructors
 impl ParquetType {
     pub fn new_root(name: String, fields: Vec<ParquetType>) -> Self {
-        let basic_info = BasicTypeInfo::new(name, Repetition::OPTIONAL, None, true);
+        let basic_info = BasicTypeInfo::new(name, Repetition::Optional, None, true);
         ParquetType::GroupType {
             basic_info,
             fields,
@@ -114,7 +114,7 @@ impl ParquetType {
         id: Option<i32>,
     ) -> Self {
         let basic_info =
-            BasicTypeInfo::new(name, repetition.unwrap_or(Repetition::OPTIONAL), id, false);
+            BasicTypeInfo::new(name, repetition.unwrap_or(Repetition::Optional), id, false);
         ParquetType::GroupType {
             basic_info,
             fields,
@@ -145,7 +145,7 @@ impl ParquetType {
     }
 
     pub fn from_physical(name: String, physical_type: PhysicalType) -> Self {
-        let basic_info = BasicTypeInfo::new(name, Repetition::OPTIONAL, None, false);
+        let basic_info = BasicTypeInfo::new(name, Repetition::Optional, None, false);
         ParquetType::PrimitiveType {
             basic_info,
             converted_type: None,

--- a/src/schema/types/physical_type.rs
+++ b/src/schema/types/physical_type.rs
@@ -15,30 +15,31 @@ pub enum PhysicalType {
 
 pub fn type_to_physical_type(type_: &Type, length: Option<i32>) -> Result<PhysicalType> {
     Ok(match type_ {
-        Type::Boolean => PhysicalType::Boolean,
-        Type::Int32 => PhysicalType::Int32,
-        Type::Int64 => PhysicalType::Int64,
-        Type::Int96 => PhysicalType::Int96,
-        Type::Float => PhysicalType::Float,
-        Type::Double => PhysicalType::Double,
-        Type::ByteArray => PhysicalType::ByteArray,
-        Type::FixedLenByteArray => {
+        &Type::BOOLEAN => PhysicalType::Boolean,
+        &Type::INT32 => PhysicalType::Int32,
+        &Type::INT64 => PhysicalType::Int64,
+        &Type::INT96 => PhysicalType::Int96,
+        &Type::FLOAT => PhysicalType::Float,
+        &Type::DOUBLE => PhysicalType::Double,
+        &Type::BYTE_ARRAY => PhysicalType::ByteArray,
+        &Type::FIXED_LEN_BYTE_ARRAY => {
             let length = length
                 .ok_or_else(|| general_err!("Length must be defined for FixedLenByteArray"))?;
             PhysicalType::FixedLenByteArray(length)
         }
+        _ => unreachable!(),
     })
 }
 
 pub fn physical_type_to_type(physical_type: &PhysicalType) -> (Type, Option<i32>) {
     match physical_type {
-        PhysicalType::Boolean => (Type::Boolean, None),
-        PhysicalType::Int32 => (Type::Int32, None),
-        PhysicalType::Int64 => (Type::Int64, None),
-        PhysicalType::Int96 => (Type::Int96, None),
-        PhysicalType::Float => (Type::Float, None),
-        PhysicalType::Double => (Type::Double, None),
-        PhysicalType::ByteArray => (Type::ByteArray, None),
-        PhysicalType::FixedLenByteArray(length) => (Type::FixedLenByteArray, Some(*length)),
+        PhysicalType::Boolean => (Type::BOOLEAN, None),
+        PhysicalType::Int32 => (Type::INT32, None),
+        PhysicalType::Int64 => (Type::INT64, None),
+        PhysicalType::Int96 => (Type::INT96, None),
+        PhysicalType::Float => (Type::FLOAT, None),
+        PhysicalType::Double => (Type::DOUBLE, None),
+        PhysicalType::ByteArray => (Type::BYTE_ARRAY, None),
+        PhysicalType::FixedLenByteArray(length) => (Type::FIXED_LEN_BYTE_ARRAY, Some(*length)),
     }
 }

--- a/src/schema/types/physical_type.rs
+++ b/src/schema/types/physical_type.rs
@@ -14,15 +14,15 @@ pub enum PhysicalType {
 }
 
 pub fn type_to_physical_type(type_: &Type, length: Option<i32>) -> Result<PhysicalType> {
-    Ok(match type_ {
-        &Type::BOOLEAN => PhysicalType::Boolean,
-        &Type::INT32 => PhysicalType::Int32,
-        &Type::INT64 => PhysicalType::Int64,
-        &Type::INT96 => PhysicalType::Int96,
-        &Type::FLOAT => PhysicalType::Float,
-        &Type::DOUBLE => PhysicalType::Double,
-        &Type::BYTE_ARRAY => PhysicalType::ByteArray,
-        &Type::FIXED_LEN_BYTE_ARRAY => {
+    Ok(match *type_ {
+        Type::BOOLEAN => PhysicalType::Boolean,
+        Type::INT32 => PhysicalType::Int32,
+        Type::INT64 => PhysicalType::Int64,
+        Type::INT96 => PhysicalType::Int96,
+        Type::FLOAT => PhysicalType::Float,
+        Type::DOUBLE => PhysicalType::Double,
+        Type::BYTE_ARRAY => PhysicalType::ByteArray,
+        Type::FIXED_LEN_BYTE_ARRAY => {
             let length = length
                 .ok_or_else(|| general_err!("Length must be defined for FixedLenByteArray"))?;
             PhysicalType::FixedLenByteArray(length)

--- a/src/schema/types/spec.rs
+++ b/src/schema/types/spec.rs
@@ -115,7 +115,7 @@ pub fn check_logical_invariants(
     physical_type: &PhysicalType,
     logical_type: &Option<LogicalType>,
 ) -> Result<()> {
-    use parquet_format::LogicalType::*;
+    use parquet_format_async_temp::LogicalType::*;
     if logical_type.is_none() {
         return Ok(());
     };

--- a/src/statistics/binary.rs
+++ b/src/statistics/binary.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use parquet_format::Statistics as ParquetStatistics;
+use parquet_format_async_temp::Statistics as ParquetStatistics;
 
 use super::Statistics;
 use crate::{error::Result, metadata::ColumnDescriptor, schema::types::PhysicalType};

--- a/src/statistics/boolean.rs
+++ b/src/statistics/boolean.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use parquet_format::Statistics as ParquetStatistics;
+use parquet_format_async_temp::Statistics as ParquetStatistics;
 
 use super::Statistics;
 use crate::{

--- a/src/statistics/fixed_len_binary.rs
+++ b/src/statistics/fixed_len_binary.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use parquet_format::Statistics as ParquetStatistics;
+use parquet_format_async_temp::Statistics as ParquetStatistics;
 
 use super::Statistics;
 use crate::{

--- a/src/statistics/mod.rs
+++ b/src/statistics/mod.rs
@@ -5,7 +5,7 @@ mod primitive;
 
 use std::{any::Any, sync::Arc};
 
-pub use parquet_format::Statistics as ParquetStatistics;
+pub use parquet_format_async_temp::Statistics as ParquetStatistics;
 
 use crate::error::Result;
 use crate::metadata::ColumnDescriptor;

--- a/src/statistics/primitive.rs
+++ b/src/statistics/primitive.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use parquet_format::Statistics as ParquetStatistics;
+use parquet_format_async_temp::Statistics as ParquetStatistics;
 
 use super::Statistics;
 use crate::metadata::ColumnDescriptor;

--- a/src/write/column_chunk.rs
+++ b/src/write/column_chunk.rs
@@ -1,9 +1,11 @@
 use std::io::{Seek, Write};
 use std::{collections::HashSet, error::Error};
 
-use parquet_format::{ColumnChunk, ColumnMetaData, CompressionCodec, Encoding, PageType};
-use thrift::protocol::TCompactOutputProtocol;
-use thrift::protocol::TOutputProtocol;
+use parquet_format_async_temp::thrift::protocol::TCompactOutputProtocol;
+use parquet_format_async_temp::thrift::protocol::TOutputProtocol;
+use parquet_format_async_temp::{
+    ColumnChunk, ColumnMetaData, CompressionCodec, Encoding, PageType,
+};
 
 use crate::statistics::serialize_statistics;
 use crate::{

--- a/src/write/column_chunk.rs
+++ b/src/write/column_chunk.rs
@@ -1,17 +1,18 @@
+use std::convert::TryInto;
 use std::io::{Seek, Write};
 use std::{collections::HashSet, error::Error};
 
 use parquet_format_async_temp::thrift::protocol::TCompactOutputProtocol;
 use parquet_format_async_temp::thrift::protocol::TOutputProtocol;
-use parquet_format_async_temp::{
-    ColumnChunk, ColumnMetaData, CompressionCodec, Encoding, PageType,
-};
+use parquet_format_async_temp::{ColumnChunk, ColumnMetaData};
 
 use crate::statistics::serialize_statistics;
 use crate::{
+    compression::Compression,
+    encoding::Encoding,
     error::{ParquetError, Result},
     metadata::ColumnDescriptor,
-    page::CompressedPage,
+    page::{CompressedPage, PageType},
     schema::types::{physical_type_to_type, ParquetType},
 };
 
@@ -25,7 +26,7 @@ pub fn write_column_chunk<
 >(
     writer: &mut W,
     descriptor: &ColumnDescriptor,
-    codec: CompressionCodec,
+    compression: Compression,
     compressed_pages: I,
 ) -> Result<ColumnChunk> {
     // write every page
@@ -53,35 +54,43 @@ pub fn write_column_chunk<
     let data_page_offset = specs.first().map(|spec| spec.offset).unwrap_or(0) as i64;
     let num_values = specs
         .iter()
-        .map(|spec| match spec.header.type_ {
-            PageType::DATA_PAGE => spec.header.data_page_header.as_ref().unwrap().num_values as i64,
-            PageType::DATA_PAGE_V2 => {
-                spec.header.data_page_header_v2.as_ref().unwrap().num_values as i64
+        .map(|spec| {
+            let type_ = spec.header.type_.try_into().unwrap();
+            match type_ {
+                PageType::DataPage => {
+                    spec.header.data_page_header.as_ref().unwrap().num_values as i64
+                }
+                PageType::DataPageV2 => {
+                    spec.header.data_page_header_v2.as_ref().unwrap().num_values as i64
+                }
+                _ => 0, // only data pages contribute
             }
-            _ => 0, // only data pages contribute
         })
         .sum();
     let encodings = specs
         .iter()
-        .map(|spec| match spec.header.type_ {
-            PageType::DATA_PAGE => vec![
-                spec.header.data_page_header.as_ref().unwrap().encoding,
-                Encoding::RLE,
-            ],
-            PageType::DATA_PAGE_V2 => {
-                vec![
-                    spec.header.data_page_header_v2.as_ref().unwrap().encoding,
-                    Encoding::RLE,
-                ]
+        .map(|spec| {
+            let type_ = spec.header.type_.try_into().unwrap();
+            match type_ {
+                PageType::DataPage => vec![
+                    spec.header.data_page_header.as_ref().unwrap().encoding,
+                    Encoding::Rle.into(),
+                ],
+                PageType::DataPageV2 => {
+                    vec![
+                        spec.header.data_page_header_v2.as_ref().unwrap().encoding,
+                        Encoding::Rle.into(),
+                    ]
+                }
+                PageType::DictionaryPage => vec![
+                    spec.header
+                        .dictionary_page_header
+                        .as_ref()
+                        .unwrap()
+                        .encoding,
+                ],
+                _ => todo!(),
             }
-            PageType::DICTIONARY_PAGE => vec![
-                spec.header
-                    .dictionary_page_header
-                    .as_ref()
-                    .unwrap()
-                    .encoding,
-            ],
-            _ => todo!(),
         })
         .flatten()
         .collect::<HashSet<_>>() // unique
@@ -105,7 +114,7 @@ pub fn write_column_chunk<
         type_,
         encodings,
         path_in_schema: descriptor.path_in_schema().to_vec(),
-        codec,
+        codec: compression.into(),
         num_values,
         total_uncompressed_size,
         total_compressed_size,

--- a/src/write/file.rs
+++ b/src/write/file.rs
@@ -3,10 +3,10 @@ use std::{
     io::{Seek, SeekFrom, Write},
 };
 
-use parquet_format::FileMetaData;
+use parquet_format_async_temp::FileMetaData;
 
-use thrift::protocol::TCompactOutputProtocol;
-use thrift::protocol::TOutputProtocol;
+use parquet_format_async_temp::thrift::protocol::TCompactOutputProtocol;
+use parquet_format_async_temp::thrift::protocol::TOutputProtocol;
 
 pub use crate::metadata::KeyValue;
 use crate::{

--- a/src/write/file.rs
+++ b/src/write/file.rs
@@ -81,6 +81,8 @@ where
         key_value_metadata,
         created_by,
         None,
+        None,
+        None,
     );
 
     end_file(writer, metadata)?;

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -11,7 +11,7 @@ mod dyn_iter;
 pub use dyn_iter::DynIter;
 
 pub use file::write_file;
-use parquet_format::CompressionCodec;
+use parquet_format_async_temp::CompressionCodec;
 
 use crate::page::CompressedPage;
 

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -11,8 +11,8 @@ mod dyn_iter;
 pub use dyn_iter::DynIter;
 
 pub use file::write_file;
-use parquet_format_async_temp::CompressionCodec;
 
+use crate::compression::Compression;
 use crate::page::CompressedPage;
 
 pub type RowGroupIter<'a, E> =
@@ -21,7 +21,7 @@ pub type RowGroupIter<'a, E> =
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct WriteOptions {
     pub write_statistics: bool,
-    pub compression: CompressionCodec,
+    pub compression: Compression,
     pub version: Version,
 }
 

--- a/src/write/page.rs
+++ b/src/write/page.rs
@@ -1,9 +1,9 @@
 use std::io::{Seek, SeekFrom, Write};
 use std::sync::Arc;
 
-use parquet_format::{DictionaryPageHeader, Encoding, PageType};
-use thrift::protocol::TCompactOutputProtocol;
-use thrift::protocol::TOutputProtocol;
+use parquet_format_async_temp::thrift::protocol::TCompactOutputProtocol;
+use parquet_format_async_temp::thrift::protocol::TOutputProtocol;
+use parquet_format_async_temp::{DictionaryPageHeader, Encoding, PageType};
 
 use crate::error::Result;
 use crate::page::{

--- a/src/write/page.rs
+++ b/src/write/page.rs
@@ -57,8 +57,8 @@ pub fn write_page<W: Write + Seek>(
 fn assemble_data_page_header(compressed_page: &CompressedDataPage) -> ParquetPageHeader {
     let mut page_header = ParquetPageHeader {
         type_: match compressed_page.header() {
-            DataPageHeader::V1(_) => PageType::DataPage,
-            DataPageHeader::V2(_) => PageType::DataPageV2,
+            DataPageHeader::V1(_) => PageType::DATA_PAGE,
+            DataPageHeader::V2(_) => PageType::DATA_PAGE_V2,
         },
         uncompressed_page_size: compressed_page.uncompressed_size() as i32,
         compressed_page_size: compressed_page.compressed_size() as i32,
@@ -82,7 +82,7 @@ fn assemble_data_page_header(compressed_page: &CompressedDataPage) -> ParquetPag
 
 fn assemble_dict_page_header(page: &CompressedDictPage) -> ParquetPageHeader {
     ParquetPageHeader {
-        type_: PageType::DictionaryPage,
+        type_: PageType::DICTIONARY_PAGE,
         uncompressed_page_size: page.buffer.len() as i32,
         compressed_page_size: page.buffer.len() as i32,
         crc: None,
@@ -90,7 +90,7 @@ fn assemble_dict_page_header(page: &CompressedDictPage) -> ParquetPageHeader {
         index_page_header: None,
         dictionary_page_header: Some(DictionaryPageHeader {
             num_values: page.num_values as i32,
-            encoding: Encoding::Plain,
+            encoding: Encoding::PLAIN,
             is_sorted: None,
         }),
         data_page_header_v2: None,

--- a/src/write/row_group.rs
+++ b/src/write/row_group.rs
@@ -72,5 +72,8 @@ where
         total_byte_size,
         num_rows,
         sorting_columns: None,
+        file_offset: None,
+        total_compressed_size: None,
+        ordinal: None,
     })
 }

--- a/src/write/row_group.rs
+++ b/src/write/row_group.rs
@@ -3,9 +3,10 @@ use std::{
     io::{Seek, Write},
 };
 
-use parquet_format_async_temp::{CompressionCodec, RowGroup};
+use parquet_format_async_temp::RowGroup;
 
 use crate::{
+    compression::Compression,
     error::{ParquetError, Result},
     metadata::ColumnDescriptor,
     page::CompressedPage,
@@ -31,7 +32,7 @@ pub fn write_row_group<
 >(
     writer: &mut W,
     descriptors: &[ColumnDescriptor],
-    codec: CompressionCodec,
+    compression: Compression,
     columns: DynIter<std::result::Result<DynIter<std::result::Result<CompressedPage, E>>, E>>,
 ) -> Result<RowGroup>
 where
@@ -45,7 +46,7 @@ where
             write_column_chunk(
                 writer,
                 descriptor,
-                codec,
+                compression,
                 page_iter.map_err(ParquetError::from_external_error)?,
             )
         })

--- a/src/write/row_group.rs
+++ b/src/write/row_group.rs
@@ -3,7 +3,7 @@ use std::{
     io::{Seek, Write},
 };
 
-use parquet_format::{CompressionCodec, RowGroup};
+use parquet_format_async_temp::{CompressionCodec, RowGroup};
 
 use crate::{
     error::{ParquetError, Result},

--- a/src/write/stream.rs
+++ b/src/write/stream.rs
@@ -7,7 +7,7 @@ use std::{
     io::{Seek, Write},
 };
 
-use parquet_format::FileMetaData;
+use parquet_format_async_temp::FileMetaData;
 
 pub use crate::metadata::KeyValue;
 use crate::{

--- a/src/write/stream.rs
+++ b/src/write/stream.rs
@@ -56,6 +56,8 @@ where
         key_value_metadata,
         created_by,
         None,
+        None,
+        None,
     );
 
     end_file(writer, metadata)?;


### PR DESCRIPTION
Closes #32 

# Backward incompatible changes

Thrift code generation had a disruptive change from 0.13 (which `parquet-format` depends on) to `0.15` (latest thrift): thrift enums are no longer generated into rust enums in Camel case, but to structs with CAPITAL cases. Since this library uses enums for compile-time validation of the parameters (e.g. Compression), and because enums are the de facto way in rust of handling these, this PR had to bridge some of the APIs exposed by the code generation.

This also allowed to review all dependencies on the `parquet-format` and adjust accordingly. Therefore:

* `Encoding` is now only exposed in `encoding::Encoding`
* `CompressionCodec` was renamed to `Compression` and is only exposed in `compression::Compression`
* There is now a trait `DataPageHeaderExt` to access some attributes from the code-generated `DataPageHeader` from `parquet-format` as this crates's enums (i.e. it performs the conversion automatically so that we do not have to worry about that).

# Other notes

This replaces `thrift` and `parquet-format` by `parquet-format-async-temp` that contains a minimal thrift library to handle `sync` and `async`, together with the parquet-generated code against it using the compiler version that supports `async`. That crate is basically https://github.com/apache/thrift/pull/2426 and https://github.com/apache/thrift/pull/2426 in a single crate and exists because thrift has 2 releases every year or so and the PR has been 6 days without feedback, suggesting some delay on that front. Once these land, we migrate back to `parquet-format-rs` and `thrift`.

