### PR TITLE
Added option to apply filter pushdown to data pages.

### DIFF
--- a/integration-tests/src/read/mod.rs
+++ b/integration-tests/src/read/mod.rs
@@ -102,7 +102,7 @@ pub(crate) mod tests {
             .descriptor()
             .clone();
 
-        let iterator = get_page_iterator(&metadata, row_group, column, reader, vec![])?;
+        let iterator = get_page_iterator(&metadata, row_group, column, reader, None, vec![])?;
 
         let buffer = vec![];
         let mut iterator = Decompressor::new(iterator, buffer);


### PR DESCRIPTION
This PR adds an ability to push filtering to individual data pages when reading. This is useful because individual pages also have statistics in their header that can be used to filter.

# Backward incompatible changes

The function `get_page_iterator` now expects an optional `Arc<Fn(&ColumnDescriptor, &DataPageHeader) -> bool>` that can be used to skip the page from the iteration.  To migrate, pass `None` or a `Some(Arc(|_,_| true))` to recover the previous behavior.