### PR TITLE
Added support to write to async writers.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ name = "parquet2"
 bench = false
 
 [dependencies]
-parquet-format-async-temp = "0.1.0"
+parquet-format-async-temp = "0.1.1"
 bitpacking = { version = "0.8.2", features = ["bitpacker1x"] }
 streaming-iterator = "0.1.5"
 

--- a/src/write/dyn_iter.rs
+++ b/src/write/dyn_iter.rs
@@ -1,9 +1,9 @@
 /// [`DynIter`] is an implementation of a single-threaded, dynamically-typed iterator.
-pub struct DynIter<'a, V> {
-    iter: Box<dyn Iterator<Item = V> + 'a>,
+pub struct DynIter<V> {
+    iter: Box<dyn Iterator<Item = V>>,
 }
 
-impl<'iter, V> Iterator for DynIter<'iter, V> {
+impl<V> Iterator for DynIter<V> {
     type Item = V;
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next()
@@ -14,10 +14,10 @@ impl<'iter, V> Iterator for DynIter<'iter, V> {
     }
 }
 
-impl<'iter, V> DynIter<'iter, V> {
+impl<V> DynIter<V> {
     pub fn new<I>(iter: I) -> Self
     where
-        I: Iterator<Item = V> + 'iter,
+        I: Iterator<Item = V> + 'static,
     {
         Self {
             iter: Box::new(iter),

--- a/src/write/file.rs
+++ b/src/write/file.rs
@@ -44,7 +44,7 @@ pub(super) fn end_file<W: Write + Seek>(mut writer: &mut W, metadata: FileMetaDa
     Ok(())
 }
 
-pub fn write_file<'a, W, I, E>(
+pub fn write_file<W, I, E>(
     writer: &mut W,
     row_groups: I,
     schema: SchemaDescriptor,
@@ -54,7 +54,7 @@ pub fn write_file<'a, W, I, E>(
 ) -> Result<()>
 where
     W: Write + Seek,
-    I: Iterator<Item = std::result::Result<RowGroupIter<'a, E>, E>>,
+    I: Iterator<Item = std::result::Result<RowGroupIter<E>, E>>,
     E: Error + Send + Sync + 'static,
 {
     start_file(writer)?;

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -6,6 +6,8 @@ pub(self) mod statistics;
 
 #[cfg(feature = "stream")]
 pub mod stream;
+#[cfg(feature = "stream")]
+mod stream_stream;
 
 mod dyn_iter;
 pub use dyn_iter::DynIter;
@@ -15,8 +17,8 @@ pub use file::write_file;
 use crate::compression::Compression;
 use crate::page::CompressedPage;
 
-pub type RowGroupIter<'a, E> =
-    DynIter<'a, std::result::Result<DynIter<'a, std::result::Result<CompressedPage, E>>, E>>;
+pub type RowGroupIter<E> =
+    DynIter<std::result::Result<DynIter<std::result::Result<CompressedPage, E>>, E>>;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct WriteOptions {

--- a/src/write/stream.rs
+++ b/src/write/stream.rs
@@ -28,7 +28,7 @@ pub async fn write_stream<'a, W, S, E>(
 ) -> Result<()>
 where
     W: Write + Seek,
-    S: Stream<Item = std::result::Result<RowGroupIter<'a, E>, E>>,
+    S: Stream<Item = std::result::Result<RowGroupIter<E>, E>>,
     E: Error + Send + Sync + 'static,
 {
     start_file(writer)?;
@@ -63,3 +63,5 @@ where
     end_file(writer, metadata)?;
     Ok(())
 }
+
+pub use super::stream_stream::write_stream_stream;

--- a/src/write/stream_stream.rs
+++ b/src/write/stream_stream.rs
@@ -1,0 +1,102 @@
+use std::{
+    error::Error,
+    io::{SeekFrom, Write},
+};
+
+use futures::{
+    pin_mut, stream::Stream, AsyncSeek, AsyncSeekExt, AsyncWrite, AsyncWriteExt, StreamExt,
+};
+
+use parquet_format_async_temp::{
+    thrift::protocol::{TCompactOutputStreamProtocol, TOutputStreamProtocol},
+    FileMetaData,
+};
+
+use crate::{
+    error::{ParquetError, Result},
+    metadata::{KeyValue, SchemaDescriptor},
+    FOOTER_SIZE, PARQUET_MAGIC,
+};
+
+use super::{row_group::write_row_group_async, RowGroupIter, WriteOptions};
+
+async fn start_file<W: AsyncWrite + Unpin>(writer: &mut W) -> Result<()> {
+    Ok(writer.write_all(&PARQUET_MAGIC).await?)
+}
+
+async fn end_file<W: AsyncWrite + AsyncSeek + Unpin + Send>(
+    mut writer: &mut W,
+    metadata: FileMetaData,
+) -> Result<()> {
+    // Write file metadata
+    let start_pos = writer.seek(SeekFrom::Current(0)).await?;
+    {
+        let mut protocol = TCompactOutputStreamProtocol::new(&mut writer);
+        metadata.write_to_out_stream_protocol(&mut protocol).await?;
+        protocol.flush().await?
+    }
+    let end_pos = writer.seek(SeekFrom::Current(0)).await?;
+    let metadata_len = (end_pos - start_pos) as i32;
+
+    // Write footer
+    let metadata_len = metadata_len.to_le_bytes();
+    let mut footer_buffer = [0u8; FOOTER_SIZE as usize];
+    (0..4).for_each(|i| {
+        footer_buffer[i] = metadata_len[i];
+    });
+
+    (&mut footer_buffer[4..]).write_all(&PARQUET_MAGIC)?;
+    writer.write_all(&footer_buffer).await?;
+    Ok(())
+}
+
+/// Given a stream of [`RowGroupIter`] and and an `async` writer, returns a future
+/// of writing a parquet file to the writer.
+pub async fn write_stream_stream<W, S, E>(
+    writer: &mut W,
+    row_groups: S,
+    schema: SchemaDescriptor,
+    options: WriteOptions,
+    created_by: Option<String>,
+    key_value_metadata: Option<Vec<KeyValue>>,
+) -> Result<()>
+where
+    W: AsyncWrite + AsyncSeek + Unpin + Send,
+    S: Stream<Item = std::result::Result<RowGroupIter<E>, E>>,
+    E: Error + Send + Sync + 'static,
+{
+    start_file(writer).await?;
+
+    let mut row_groups_c = vec![];
+
+    pin_mut!(row_groups);
+    while let Some(row_group) = row_groups.next().await {
+        //for row_group in row_groups {
+        let row_group = write_row_group_async(
+            writer,
+            schema.columns(),
+            options.compression,
+            row_group.map_err(ParquetError::from_external_error)?,
+        )
+        .await?;
+        row_groups_c.push(row_group);
+    }
+
+    // compute file stats
+    let num_rows = row_groups_c.iter().map(|group| group.num_rows).sum();
+
+    let metadata = FileMetaData::new(
+        options.version.into(),
+        schema.into_thrift()?,
+        num_rows,
+        row_groups_c,
+        key_value_metadata,
+        created_by,
+        None,
+        None,
+        None,
+    );
+
+    end_file(writer, metadata).await?;
+    Ok(())
+}


### PR DESCRIPTION
This PR adds support to write to `AsyncWrite + AsyncSeek (+ Unpin + Send)`.

The need for `AsyncSeek` is due to a current limitation of thrift that does not report how many bytes were written in their protocols. This implementation only calls `seek` of `SeekFrom::Current(0)` before and after writing to compute how much bytes were written between the calls.

# Backward incompatible changes

* `DynIter` no longer has a lifetime parameter (it was not needed and made the `async` implementation more difficult).