### PR TITLE
Simplified API to get page iterator

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@ distribute work across threads. E.g.
 ```rust 
 let handles = vec![];
 for column in columns {
-    let compressed_pages = get_page_iterator(&metadata, row_group, column, &mut file, file)?.collect()?;
+    let column_meta = metadata.row_groups[row_group].column(column);
+    let compressed_pages = get_page_iterator(column_meta, &mut file, file)?.collect()?;
     // each compressed_page has a buffer; cloning is expensive(!). We move it so that the memory
     // is released at the end of the processing.
     handles.push(thread::spawn move {

--- a/examples/s3/src/main.rs
+++ b/examples/s3/src/main.rs
@@ -49,9 +49,11 @@ async fn main() -> Result<()> {
 
     // * first row group
     // * first column
+    let column_metadata = metadata.row_groups[row_group].column(column);
+
     // * do not skip any pages
     let pages =
-        get_page_stream(&metadata, 0, 0, &mut reader, vec![], Arc::new(|_, _| true)).await?;
+        get_page_stream(&column_metadata, &mut reader, vec![], Arc::new(|_, _| true)).await?;
 
     pin_mut!(pages); // needed for iteration
 

--- a/integration-tests/src/read/mod.rs
+++ b/integration-tests/src/read/mod.rs
@@ -97,20 +97,15 @@ pub(crate) mod tests {
         column: usize,
     ) -> Result<(Array, Option<std::sync::Arc<dyn Statistics>>)> {
         let metadata = read_metadata(reader)?;
-        let descriptor = metadata.row_groups[row_group]
-            .column(column)
-            .descriptor()
-            .clone();
+        let column_meta = metadata.row_groups[row_group].column(column);
+        let descriptor = column_meta.descriptor().clone();
 
-        let iterator = get_page_iterator(&metadata, row_group, column, reader, None, vec![])?;
+        let iterator = get_page_iterator(&column_meta, reader, None, vec![])?;
 
         let buffer = vec![];
         let mut iterator = Decompressor::new(iterator, buffer);
 
-        let statistics = metadata.row_groups[row_group]
-            .column(column)
-            .statistics()
-            .transpose()?;
+        let statistics = column_meta.statistics().transpose()?;
 
         let page = iterator.next().unwrap().as_ref().unwrap();
 

--- a/parquet-tools/src/lib/dump.rs
+++ b/parquet-tools/src/lib/dump.rs
@@ -47,7 +47,8 @@ where
         writeln!(writer, "{}", SEPARATOR)?;
 
         for column in &columns {
-            let iter = get_page_iterator(&metadata, i, *column, &mut file)?;
+            let column_meta = group.column(column);
+            let iter = get_page_iterator(column_meta, &mut file)?;
             for (page_ind, page) in iter.enumerate() {
                 let page = page?;
                 writeln!(


### PR DESCRIPTION
old:
```rust
pub fn get_page_iterator<'a, RR: Read + Seek>(metadata: &FileMetaData, row_group: usize, column: usize, ...)
```

new:
```rust
pub fn get_page_iterator<'a, RR: Read + Seek>(column_metadata: &ColumnChunkMetaData, ...)
```

it makes it a bit more explicit and users usually already get the column metadata, to get the file descriptor and stats (code duplication of consumers).

To migrate, 

before:
```rust
let compressed_pages = get_page_iterator(&metadata, row_group, column, &mut file, file)?.collect()?;
```

after:
```rust
let column_meta = metadata.row_groups[row_group].column(column);
let compressed_pages = get_page_iterator(column_meta, &mut file, file)?.collect()?;
```