### PR TITLE
Simplified split of page buffer

### DIFF
--- a/src/read/compression.rs
+++ b/src/read/compression.rs
@@ -66,6 +66,8 @@ pub fn decompress_buffer(
 }
 
 /// Decompresses the page, using `buffer` for decompression.
+/// If `page.buffer.len() == 0`, there was no decompression and the buffer was moved.
+/// Else, decompression took place.
 pub fn decompress(
     mut compressed_page: CompressedDataPage,
     buffer: &mut Vec<u8>,

--- a/src/read/levels.rs
+++ b/src/read/levels.rs
@@ -1,4 +1,4 @@
-use crate::encoding::{bitpacking, get_length, hybrid_rle};
+use crate::encoding::{bitpacking, hybrid_rle};
 
 /// Returns the number of bits needed to store the given maximum definition or repetition level.
 #[inline]
@@ -101,45 +101,6 @@ impl<'a> Iterator for RLEDecoder<'a> {
 }
 
 impl<'a> ExactSizeIterator for RLEDecoder<'a> {}
-
-/// returns slices corresponding to (rep, def, values) for v1 pages
-#[inline]
-pub fn split_buffer_v1(buffer: &[u8], has_rep: bool, has_def: bool) -> (&[u8], &[u8], &[u8]) {
-    let (rep, buffer) = if has_rep {
-        let level_buffer_length = get_length(buffer) as usize;
-        (
-            &buffer[4..4 + level_buffer_length],
-            &buffer[4 + level_buffer_length..],
-        )
-    } else {
-        (&[] as &[u8], buffer)
-    };
-
-    let (def, buffer) = if has_def {
-        let level_buffer_length = get_length(buffer) as usize;
-        (
-            &buffer[4..4 + level_buffer_length],
-            &buffer[4 + level_buffer_length..],
-        )
-    } else {
-        (&[] as &[u8], buffer)
-    };
-
-    (rep, def, buffer)
-}
-
-/// returns slices corresponding to (rep, def, values) for v2 pages
-pub fn split_buffer_v2(
-    buffer: &[u8],
-    rep_level_buffer_length: usize,
-    def_level_buffer_length: usize,
-) -> (&[u8], &[u8], &[u8]) {
-    (
-        &buffer[..rep_level_buffer_length],
-        &buffer[rep_level_buffer_length..rep_level_buffer_length + def_level_buffer_length],
-        &buffer[rep_level_buffer_length + def_level_buffer_length..],
-    )
-}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Reduces the consumer code necessary to split and deserialize a page.

# Backward incompatible changes

* `split_buffer_v1` and `split_buffer_v2` were moved from `levels::` to `page::` (since they split the page buffer)
