### PR TITLE
Added lifetime to DynIter.

### DIFF
--- a/src/write/dyn_iter.rs
+++ b/src/write/dyn_iter.rs
@@ -1,9 +1,9 @@
 /// [`DynIter`] is an implementation of a single-threaded, dynamically-typed iterator.
-pub struct DynIter<V> {
-    iter: Box<dyn Iterator<Item = V>>,
+pub struct DynIter<'a, V> {
+    iter: Box<dyn Iterator<Item = V> + 'a>,
 }
 
-impl<V> Iterator for DynIter<V> {
+impl<'a, V> Iterator for DynIter<'a, V> {
     type Item = V;
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next()
@@ -14,10 +14,10 @@ impl<V> Iterator for DynIter<V> {
     }
 }
 
-impl<V> DynIter<V> {
+impl<'a, V> DynIter<'a, V> {
     pub fn new<I>(iter: I) -> Self
     where
-        I: Iterator<Item = V> + 'static,
+        I: Iterator<Item = V> + 'a,
     {
         Self {
             iter: Box::new(iter),

--- a/src/write/file.rs
+++ b/src/write/file.rs
@@ -44,7 +44,7 @@ pub(super) fn end_file<W: Write + Seek>(mut writer: &mut W, metadata: FileMetaDa
     Ok(())
 }
 
-pub fn write_file<W, I, E>(
+pub fn write_file<'a, W, I, E>(
     writer: &mut W,
     row_groups: I,
     schema: SchemaDescriptor,
@@ -54,7 +54,7 @@ pub fn write_file<W, I, E>(
 ) -> Result<()>
 where
     W: Write + Seek,
-    I: Iterator<Item = std::result::Result<RowGroupIter<E>, E>>,
+    I: Iterator<Item = std::result::Result<RowGroupIter<'a, E>, E>>,
     E: Error + Send + Sync + 'static,
 {
     start_file(writer)?;

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -17,8 +17,8 @@ pub use file::write_file;
 use crate::compression::Compression;
 use crate::page::CompressedPage;
 
-pub type RowGroupIter<E> =
-    DynIter<std::result::Result<DynIter<std::result::Result<CompressedPage, E>>, E>>;
+pub type RowGroupIter<'a, E> =
+    DynIter<'a, std::result::Result<DynIter<'a, std::result::Result<CompressedPage, E>>, E>>;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct WriteOptions {

--- a/src/write/row_group.rs
+++ b/src/write/row_group.rs
@@ -84,13 +84,17 @@ where
 }
 
 pub async fn write_row_group_async<
+    'a,
     W,
     E, // external error any of the iterators may emit
 >(
     writer: &mut W,
     descriptors: &[ColumnDescriptor],
     compression: Compression,
-    columns: DynIter<std::result::Result<DynIter<std::result::Result<CompressedPage, E>>, E>>,
+    columns: DynIter<
+        'a,
+        std::result::Result<DynIter<'a, std::result::Result<CompressedPage, E>>, E>,
+    >,
 ) -> Result<RowGroup>
 where
     W: AsyncWrite + AsyncSeek + Unpin + Send,

--- a/src/write/stream.rs
+++ b/src/write/stream.rs
@@ -28,7 +28,7 @@ pub async fn write_stream<'a, W, S, E>(
 ) -> Result<()>
 where
     W: Write + Seek,
-    S: Stream<Item = std::result::Result<RowGroupIter<E>, E>>,
+    S: Stream<Item = std::result::Result<RowGroupIter<'a, E>, E>>,
     E: Error + Send + Sync + 'static,
 {
     start_file(writer)?;

--- a/src/write/stream_stream.rs
+++ b/src/write/stream_stream.rs
@@ -52,7 +52,7 @@ async fn end_file<W: AsyncWrite + AsyncSeek + Unpin + Send>(
 
 /// Given a stream of [`RowGroupIter`] and and an `async` writer, returns a future
 /// of writing a parquet file to the writer.
-pub async fn write_stream_stream<W, S, E>(
+pub async fn write_stream_stream<'a, W, S, E>(
     writer: &mut W,
     row_groups: S,
     schema: SchemaDescriptor,
@@ -62,7 +62,7 @@ pub async fn write_stream_stream<W, S, E>(
 ) -> Result<()>
 where
     W: AsyncWrite + AsyncSeek + Unpin + Send,
-    S: Stream<Item = std::result::Result<RowGroupIter<E>, E>>,
+    S: Stream<Item = std::result::Result<RowGroupIter<'a, E>, E>>,
     E: Error + Send + Sync + 'static,
 {
     start_file(writer).await?;


### PR DESCRIPTION
This reverts part of a previous commit, since `'static` is (obviously) too constrained.