### PR TITLE
Removed requirement of "Seek" on write.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ name = "parquet2"
 bench = false
 
 [dependencies]
-parquet-format-async-temp = "0.1.1"
+parquet-format-async-temp = "0.2.0"
 bitpacking = { version = "0.8.2", features = ["bitpacker1x"] }
 streaming-iterator = "0.1.5"
 

--- a/src/write/stream.rs
+++ b/src/write/stream.rs
@@ -2,10 +2,7 @@ use futures::stream::Stream;
 use futures::StreamExt;
 use futures::TryStreamExt;
 
-use std::{
-    error::Error,
-    io::{Seek, Write},
-};
+use std::{error::Error, io::Write};
 
 use parquet_format_async_temp::FileMetaData;
 
@@ -25,22 +22,25 @@ pub async fn write_stream<'a, W, S, E>(
     options: WriteOptions,
     created_by: Option<String>,
     key_value_metadata: Option<Vec<KeyValue>>,
-) -> Result<()>
+) -> Result<u64>
 where
-    W: Write + Seek,
+    W: Write,
     S: Stream<Item = std::result::Result<RowGroupIter<'a, E>, E>>,
     E: Error + Send + Sync + 'static,
 {
-    start_file(writer)?;
+    let mut offset = start_file(writer)? as u64;
 
     let row_groups = row_groups
         .map(|row_group| {
-            write_row_group(
+            let (group, size) = write_row_group(
                 writer,
+                offset,
                 schema.columns(),
                 options.compression,
                 row_group.map_err(ParquetError::from_external_error)?,
-            )
+            )?;
+            offset += size;
+            Result::Ok(group)
         })
         .try_collect::<Vec<_>>()
         .await?;
@@ -60,8 +60,8 @@ where
         None,
     );
 
-    end_file(writer, metadata)?;
-    Ok(())
+    let len = end_file(writer, metadata)?;
+    Ok(offset + len)
 }
 
 pub use super::stream_stream::write_stream_stream;

--- a/src/write/stream_stream.rs
+++ b/src/write/stream_stream.rs
@@ -1,11 +1,6 @@
-use std::{
-    error::Error,
-    io::{SeekFrom, Write},
-};
+use std::{error::Error, io::Write};
 
-use futures::{
-    pin_mut, stream::Stream, AsyncSeek, AsyncSeekExt, AsyncWrite, AsyncWriteExt, StreamExt,
-};
+use futures::{pin_mut, stream::Stream, AsyncWrite, AsyncWriteExt, StreamExt};
 
 use parquet_format_async_temp::{
     thrift::protocol::{TCompactOutputStreamProtocol, TOutputStreamProtocol},
@@ -20,34 +15,30 @@ use crate::{
 
 use super::{row_group::write_row_group_async, RowGroupIter, WriteOptions};
 
-async fn start_file<W: AsyncWrite + Unpin>(writer: &mut W) -> Result<()> {
-    Ok(writer.write_all(&PARQUET_MAGIC).await?)
+async fn start_file<W: AsyncWrite + Unpin>(writer: &mut W) -> Result<u64> {
+    writer.write_all(&PARQUET_MAGIC).await?;
+    Ok(PARQUET_MAGIC.len() as u64)
 }
 
-async fn end_file<W: AsyncWrite + AsyncSeek + Unpin + Send>(
+async fn end_file<W: AsyncWrite + Unpin + Send>(
     mut writer: &mut W,
     metadata: FileMetaData,
-) -> Result<()> {
+) -> Result<u64> {
     // Write file metadata
-    let start_pos = writer.seek(SeekFrom::Current(0)).await?;
-    {
-        let mut protocol = TCompactOutputStreamProtocol::new(&mut writer);
-        metadata.write_to_out_stream_protocol(&mut protocol).await?;
-        protocol.flush().await?
-    }
-    let end_pos = writer.seek(SeekFrom::Current(0)).await?;
-    let metadata_len = (end_pos - start_pos) as i32;
+    let mut protocol = TCompactOutputStreamProtocol::new(&mut writer);
+    let metadata_len = metadata.write_to_out_stream_protocol(&mut protocol).await? as i32;
+    protocol.flush().await?;
 
     // Write footer
-    let metadata_len = metadata_len.to_le_bytes();
+    let metadata_bytes = metadata_len.to_le_bytes();
     let mut footer_buffer = [0u8; FOOTER_SIZE as usize];
     (0..4).for_each(|i| {
-        footer_buffer[i] = metadata_len[i];
+        footer_buffer[i] = metadata_bytes[i];
     });
 
     (&mut footer_buffer[4..]).write_all(&PARQUET_MAGIC)?;
     writer.write_all(&footer_buffer).await?;
-    Ok(())
+    Ok(metadata_len as u64 + FOOTER_SIZE)
 }
 
 /// Given a stream of [`RowGroupIter`] and and an `async` writer, returns a future
@@ -59,26 +50,27 @@ pub async fn write_stream_stream<'a, W, S, E>(
     options: WriteOptions,
     created_by: Option<String>,
     key_value_metadata: Option<Vec<KeyValue>>,
-) -> Result<()>
+) -> Result<u64>
 where
-    W: AsyncWrite + AsyncSeek + Unpin + Send,
+    W: AsyncWrite + Unpin + Send,
     S: Stream<Item = std::result::Result<RowGroupIter<'a, E>, E>>,
     E: Error + Send + Sync + 'static,
 {
-    start_file(writer).await?;
+    let mut offset = start_file(writer).await?;
 
     let mut row_groups_c = vec![];
 
     pin_mut!(row_groups);
     while let Some(row_group) = row_groups.next().await {
-        //for row_group in row_groups {
-        let row_group = write_row_group_async(
+        let (row_group, size) = write_row_group_async(
             writer,
+            offset,
             schema.columns(),
             options.compression,
             row_group.map_err(ParquetError::from_external_error)?,
         )
         .await?;
+        offset += size;
         row_groups_c.push(row_group);
     }
 
@@ -97,6 +89,6 @@ where
         None,
     );
 
-    end_file(writer, metadata).await?;
-    Ok(())
+    let len = end_file(writer, metadata).await?;
+    Ok(offset + len)
 }


### PR DESCRIPTION
Many remote writers (e.g. s3) either do not support such a requirement or making them are expensive and/or brittle.

Also closes #45.