### PR TITLE
Compression enum typo

### DIFF
--- a/src/compression.rs
+++ b/src/compression.rs
@@ -46,7 +46,7 @@ pub fn create_codec(codec: &Compression) -> Result<Option<Box<dyn Codec>>> {
         #[cfg(feature = "lz4")]
         Compression::Lz4 => Ok(Some(Box::new(Lz4Codec::new()))),
         #[cfg(feature = "zstd")]
-        Compression::Zsld => Ok(Some(Box::new(ZstdCodec::new()))),
+        Compression::Zstd => Ok(Some(Box::new(ZstdCodec::new()))),
         Compression::Uncompressed => Ok(None),
         _ => Err(general_err!("Compression {:?} is not installed", codec)),
     }
@@ -329,6 +329,6 @@ mod tests {
 
     #[test]
     fn test_codec_zstd() {
-        test_codec(Compression::Zsld);
+        test_codec(Compression::Zstd);
     }
 }

--- a/src/parquet_bridge.rs
+++ b/src/parquet_bridge.rs
@@ -48,7 +48,7 @@ pub enum Compression {
     Lzo,
     Brotli,
     Lz4,
-    Zsld,
+    Zstd,
 }
 
 impl TryFrom<CompressionCodec> for Compression {
@@ -62,7 +62,7 @@ impl TryFrom<CompressionCodec> for Compression {
             CompressionCodec::LZO => Compression::Lzo,
             CompressionCodec::BROTLI => Compression::Brotli,
             CompressionCodec::LZ4 => Compression::Lz4,
-            CompressionCodec::ZSTD => Compression::Zsld,
+            CompressionCodec::ZSTD => Compression::Zstd,
             _ => return Err(ParquetError::OutOfSpec("Thrift out of range".to_string())),
         })
     }
@@ -77,7 +77,7 @@ impl From<Compression> for CompressionCodec {
             Compression::Lzo => CompressionCodec::LZO,
             Compression::Brotli => CompressionCodec::BROTLI,
             Compression::Lz4 => CompressionCodec::LZ4,
-            Compression::Zsld => CompressionCodec::ZSTD,
+            Compression::Zstd => CompressionCodec::ZSTD,
         }
     }
 }


### PR DESCRIPTION
I've just noticed the typo while writing a Zstd compressed Parquet.