### PR TITLE
Inlined hot `next` of decoders.

### DIFF
--- a/src/encoding/bitpacking.rs
+++ b/src/encoding/bitpacking.rs
@@ -69,6 +69,7 @@ fn decode_pack(compressed: &[u8], num_bits: u8, pack: &mut [u32; BitPacker1x::BL
 }
 
 impl<'a> Decoder<'a> {
+    #[inline]
     pub fn new(compressed: &'a [u8], num_bits: u8, length: usize) -> Self {
         let compressed_block_size = BitPacker1x::BLOCK_LEN * num_bits as usize / 8;
 
@@ -93,6 +94,7 @@ impl<'a> Decoder<'a> {
 impl<'a> Iterator for Decoder<'a> {
     type Item = u32;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         if self.remaining == 0 {
             return None;
@@ -109,6 +111,7 @@ impl<'a> Iterator for Decoder<'a> {
         Some(result)
     }
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         (self.remaining, Some(self.remaining))
     }

--- a/src/encoding/delta_bitpacked/decoder.rs
+++ b/src/encoding/delta_bitpacked/decoder.rs
@@ -67,6 +67,7 @@ impl<'a> Block<'a> {
 impl<'a> Iterator for Block<'a> {
     type Item = u32;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         if self.remaining == 0 {
             return None;
@@ -162,6 +163,7 @@ impl<'a> Decoder<'a> {
 impl<'a> Iterator for Decoder<'a> {
     type Item = i32;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         if self.total_count == 0 {
             return None;

--- a/src/encoding/delta_byte_array/decoder.rs
+++ b/src/encoding/delta_byte_array/decoder.rs
@@ -29,6 +29,7 @@ impl<'a> Decoder<'a> {
 impl<'a> Iterator for Decoder<'a> {
     type Item = u32;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.prefix_lengths.next().map(|x| x as u32)
     }

--- a/src/encoding/delta_length_byte_array/decoder.rs
+++ b/src/encoding/delta_length_byte_array/decoder.rs
@@ -56,6 +56,7 @@ impl<'a> Decoder<'a> {
 impl<'a> Iterator for Decoder<'a> {
     type Item = i32;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         let result = self.lengths.next();
         if let Some(result) = result {

--- a/src/encoding/hybrid_rle/decoder.rs
+++ b/src/encoding/hybrid_rle/decoder.rs
@@ -9,11 +9,13 @@ pub struct Decoder<'a> {
 }
 
 impl<'a> Decoder<'a> {
+    #[inline]
     pub fn new(values: &'a [u8], num_bits: u32) -> Self {
         Self { values, num_bits }
     }
 
     /// Returns the number of bits being used by this decoder.
+    #[inline]
     pub fn num_bits(&self) -> u32 {
         self.num_bits
     }
@@ -22,6 +24,7 @@ impl<'a> Decoder<'a> {
 impl<'a> Iterator for Decoder<'a> {
     type Item = HybridEncoded<'a>;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         if self.values.is_empty() {
             return None;

--- a/src/encoding/hybrid_rle/mod.rs
+++ b/src/encoding/hybrid_rle/mod.rs
@@ -29,6 +29,7 @@ pub struct HybridRleDecoder<'a> {
     remaining: usize,
 }
 
+#[inline]
 fn read_next<'a, 'b>(decoder: &'b mut Decoder<'a>, remaining: usize) -> State<'a> {
     let state = decoder.next().unwrap();
     match state {
@@ -50,6 +51,7 @@ fn read_next<'a, 'b>(decoder: &'b mut Decoder<'a>, remaining: usize) -> State<'a
 }
 
 impl<'a> HybridRleDecoder<'a> {
+    #[inline]
     pub fn new(data: &'a [u8], num_bits: u32, num_values: usize) -> Self {
         let mut decoder = Decoder::new(data, num_bits);
         let state = read_next(&mut decoder, num_values);
@@ -64,6 +66,7 @@ impl<'a> HybridRleDecoder<'a> {
 impl<'a> Iterator for HybridRleDecoder<'a> {
     type Item = u32;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         if self.remaining == 0 {
             return None;
@@ -81,6 +84,7 @@ impl<'a> Iterator for HybridRleDecoder<'a> {
         }
     }
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         (self.remaining, Some(self.remaining))
     }


### PR DESCRIPTION
non-inlined code does not cross crate boundaries in inlining, which is an issue for hot iterators.

Thanks to @Dandandan for identifying this [here](https://github.com/apache/arrow-datafusion/pull/68#issuecomment-922249010).