### PR TITLE
BitPacked encoding with max_def_level 0 should also result in an iterator of zeros

### DIFF
--- a/integration-tests/src/read/binary.rs
+++ b/integration-tests/src/read/binary.rs
@@ -105,7 +105,7 @@ fn read_buffer(
 ) -> Vec<Option<Vec<u8>>> {
     let max_def_level = def_level_encoding.1 as u32;
     match (def_level_encoding.0, max_def_level == 0) {
-        (Encoding::Rle, true) => read_buffer_impl(
+        (Encoding::Rle, true) | (Encoding::BitPacked, true) => read_buffer_impl(
             std::iter::repeat(0).take(length as usize),
             values,
             length,


### PR DESCRIPTION
The java parquet writer seems to write required fields using BitPacked encoding for the definition levels. With a max definition level of zero this encoding also does not use any space in the file and instead can be decoded to an iterator of zeros.