### PR TITLE
Fixed error in reading zero-width bit from hybrid RLE.

### DIFF
--- a/src/encoding/hybrid_rle/decoder.rs
+++ b/src/encoding/hybrid_rle/decoder.rs
@@ -14,6 +14,7 @@ impl<'a> Decoder<'a> {
     }
 
     /// Returns the number of bits being used by this decoder.
+    #[inline]
     pub fn num_bits(&self) -> u32 {
         self.num_bits
     }


### PR DESCRIPTION
When the decoder has a zero bit width, it means that it is always the same value (`0`). We did not take this edge case into account.