### PR TITLE
Add descriptor to `FixedLenStatistics`

### DIFF
--- a/src/statistics/mod.rs
+++ b/src/statistics/mod.rs
@@ -108,7 +108,7 @@ pub fn deserialize_statistics(
         PhysicalType::Float => primitive::read::<f32>(statistics, descriptor),
         PhysicalType::Double => primitive::read::<f64>(statistics, descriptor),
         PhysicalType::ByteArray => binary::read(statistics, descriptor),
-        PhysicalType::FixedLenByteArray(size) => fixed_len_binary::read(statistics, *size),
+        PhysicalType::FixedLenByteArray(size) => fixed_len_binary::read(statistics, *size, descriptor),
     }
 }
 


### PR DESCRIPTION
Hi,

This pull request is related to [arrow2#444](https://github.com/jorgecarleitao/arrow2/issues/444).

I just simply modify the Fix Len Statistics and it constructors to help facilitate more logical type from fix-len binary