### PR TITLE
Added basic support to read nested types

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
           cd integration-tests
           python3 -m venv venv
           venv/bin/pip install pip --upgrade
-          venv/bin/pip install pyarrow==3
+          venv/bin/pip install pyarrow==5
           venv/bin/python integration/write_pyarrow.py
           cd ..
       - name: Run integration tests
@@ -112,7 +112,7 @@ jobs:
           cd integration-tests
           python3 -m venv venv
           venv/bin/pip install pip --upgrade
-          venv/bin/pip install pyarrow==3
+          venv/bin/pip install pyarrow==5
           venv/bin/python integration/write_pyarrow.py
           cd ..
       - name: Run coverage

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 Cargo.lock
 .idea
+venv

--- a/integration-tests/integration/write_pyarrow.py
+++ b/integration-tests/integration/write_pyarrow.py
@@ -1,7 +1,6 @@
 import pyarrow as pa
 import pyarrow.parquet
 import os
-import shutil
 
 PYARROW_PATH = "fixtures/pyarrow3"
 
@@ -81,6 +80,33 @@ def case_nested(size):
     )
 
 
+def case_struct(size):
+    string = ["Hello", None, "aa", "", None, "abc", None, None, "def", "aaa"]
+    boolean = [True, None, False, False, None, True, None, None, True, True]
+    struct_fields = [
+        ("f1", pa.utf8()),
+        ("f2", pa.bool_()),
+    ]
+    fields = [
+        pa.field(
+            "struct",
+            pa.struct(struct_fields),
+        )
+    ]
+    schema = pa.schema(fields)
+    return (
+        {
+            "struct": pa.StructArray.from_arrays(
+                [pa.array(string * size), pa.array(boolean * size)],
+                fields=struct_fields,
+                mask=pa.array([False, True, True, True, True, True, True, True, True, True] * size)
+            ),
+        },
+        schema,
+        f"struct_nullable_{size*10}.parquet",
+    )
+
+
 def write_pyarrow(
     case, size=1, page_version=1, use_dictionary=False, use_compression=False
 ):
@@ -106,7 +132,7 @@ def write_pyarrow(
     )
 
 
-for case in [case_basic_nullable, case_basic_required, case_nested]:
+for case in [case_basic_nullable, case_basic_required, case_nested, case_struct]:
     for version in [1, 2]:
         for use_dict in [False, True]:
             for compression in [False, True]:

--- a/integration-tests/integration/write_pyarrow.py
+++ b/integration-tests/integration/write_pyarrow.py
@@ -83,6 +83,7 @@ def case_nested(size):
 def case_struct(size):
     string = ["Hello", None, "aa", "", None, "abc", None, None, "def", "aaa"]
     boolean = [True, None, False, False, None, True, None, None, True, True]
+    validity = [True, False, False, False, False, False, False, False, False, False]
     struct_fields = [
         ("f1", pa.utf8()),
         ("f2", pa.bool_()),
@@ -99,7 +100,7 @@ def case_struct(size):
             "struct": pa.StructArray.from_arrays(
                 [pa.array(string * size), pa.array(boolean * size)],
                 fields=struct_fields,
-                mask=pa.array([False, True, True, True, True, True, True, True, True, True] * size)
+                mask=pa.array(validity * size),
             ),
         },
         schema,

--- a/integration-tests/integration/write_pyarrow.py
+++ b/integration-tests/integration/write_pyarrow.py
@@ -90,17 +90,25 @@ def case_struct(size):
     ]
     fields = [
         pa.field(
-            "struct",
+            "struct_nullable",
             pa.struct(struct_fields),
-        )
+        ),
+        pa.field(
+            "struct_required",
+            pa.struct(struct_fields),
+        ),
     ]
     schema = pa.schema(fields)
     return (
         {
-            "struct": pa.StructArray.from_arrays(
+            "struct_nullable": pa.StructArray.from_arrays(
                 [pa.array(string * size), pa.array(boolean * size)],
                 fields=struct_fields,
                 mask=pa.array(validity * size),
+            ),
+            "struct_required": pa.StructArray.from_arrays(
+                [pa.array(string * size), pa.array(boolean * size)],
+                fields=struct_fields,
             ),
         },
         schema,

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -16,6 +16,7 @@ pub enum Array {
     Boolean(Vec<Option<bool>>),
     Binary(Vec<Option<Vec<u8>>>),
     List(Vec<Option<Array>>),
+    Struct(Vec<Array>, Vec<bool>),
 }
 
 // The dynamic representation of values in native Rust. This is not exaustive.

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -47,9 +47,6 @@ mod tests {
 
     pub fn get_path() -> PathBuf {
         let dir = env!("CARGO_MANIFEST_DIR");
-
-        println!("{}", dir);
-
         PathBuf::from(dir).join("../testing/parquet-testing/data")
     }
 
@@ -412,22 +409,40 @@ mod tests {
 
     // these values match the values in `integration`
     pub fn pyarrow_struct_optional(column: usize) -> Array {
-        //    [[0, 1], None, [2, None, 3], [4, 5, 6], [], [7, 8, 9], None, [10]]
-        // def: 3, 3,  0,     3, 2,    3,   3, 3, 3,  1    3  3  3   0      3
-        // rep: 0, 1,  0,     0, 1,    1,   0, 1, 1,  0,   0, 1, 1,  0,     0
-        let data = vec![
-            Some(Array::Int64(vec![Some(0), Some(1)])),
+        let string = vec![
             None,
-            Some(Array::Int64(vec![Some(2), None, Some(3)])),
-            Some(Array::Int64(vec![Some(4), Some(5), Some(6)])),
-            Some(Array::Int64(vec![])),
-            Some(Array::Int64(vec![Some(7), Some(8), Some(9)])),
             None,
-            Some(Array::Int64(vec![Some(10)])),
+            Some("aa".to_string()),
+            Some("".to_string()),
+            None,
+            Some("abc".to_string()),
+            None,
+            None,
+            Some("def".to_string()),
+            Some("aaa".to_string()),
+        ]
+        .into_iter()
+        .map(|s| s.map(|s| s.as_bytes().to_vec()))
+        .collect();
+        let boolean = vec![
+            None,
+            None,
+            Some(false),
+            Some(false),
+            None,
+            Some(true),
+            None,
+            None,
+            Some(true),
+            Some(true),
         ];
+        let validity = vec![false, true, true, true, true, true, true, true, true, true];
 
         match column {
-            0 => Array::List(data),
+            0 => Array::Struct(
+                vec![Array::Binary(string), Array::Boolean(boolean)],
+                validity,
+            ),
             _ => unreachable!(),
         }
     }

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -409,4 +409,26 @@ mod tests {
             _ => unreachable!(),
         }
     }
+
+    // these values match the values in `integration`
+    pub fn pyarrow_struct_optional(column: usize) -> Array {
+        //    [[0, 1], None, [2, None, 3], [4, 5, 6], [], [7, 8, 9], None, [10]]
+        // def: 3, 3,  0,     3, 2,    3,   3, 3, 3,  1    3  3  3   0      3
+        // rep: 0, 1,  0,     0, 1,    1,   0, 1, 1,  0,   0, 1, 1,  0,     0
+        let data = vec![
+            Some(Array::Int64(vec![Some(0), Some(1)])),
+            None,
+            Some(Array::Int64(vec![Some(2), None, Some(3)])),
+            Some(Array::Int64(vec![Some(4), Some(5), Some(6)])),
+            Some(Array::Int64(vec![])),
+            Some(Array::Int64(vec![Some(7), Some(8), Some(9)])),
+            None,
+            Some(Array::Int64(vec![Some(10)])),
+        ];
+
+        match column {
+            0 => Array::List(data),
+            _ => unreachable!(),
+        }
+    }
 }

--- a/integration-tests/src/read/mod.rs
+++ b/integration-tests/src/read/mod.rs
@@ -445,4 +445,19 @@ pub(crate) mod tests {
     fn pyarrow_v1_struct_optional() -> Result<()> {
         test_pyarrow_integration("struct", 0, 1, false, false, false)
     }
+
+    #[test]
+    fn pyarrow_v2_struct_optional() -> Result<()> {
+        test_pyarrow_integration("struct", 0, 2, false, false, false)
+    }
+
+    #[test]
+    fn pyarrow_v1_struct_required() -> Result<()> {
+        test_pyarrow_integration("struct", 1, 1, false, false, false)
+    }
+
+    #[test]
+    fn pyarrow_v2_struct_required() -> Result<()> {
+        test_pyarrow_integration("struct", 1, 2, false, false, false)
+    }
 }

--- a/integration-tests/src/read/mod.rs
+++ b/integration-tests/src/read/mod.rs
@@ -278,26 +278,20 @@ pub(crate) mod tests {
 
         let (array, statistics) = get_column(&path, column)?;
 
-        let expected = if file == "basic" {
-            if required {
-                pyarrow_required(column)
-            } else {
-                pyarrow_optional(column)
-            }
-        } else {
-            pyarrow_nested_optional(column)
+        let expected = match (file, required) {
+            ("basic", true) => pyarrow_required(column),
+            ("basic", false) => pyarrow_optional(column),
+            ("nested", false) => pyarrow_nested_optional(column),
+            _ => todo!(),
         };
 
         assert_eq!(expected, array);
 
-        let expected_stats = if file == "basic" {
-            if required {
-                pyarrow_required_stats(column)
-            } else {
-                pyarrow_optional_stats(column)
-            }
-        } else {
-            (Some(1), Value::Int64(Some(0)), Value::Int64(Some(10)))
+        let expected_stats = match (file, required) {
+            ("basic", true) => pyarrow_required_stats(column),
+            ("basic", false) => pyarrow_optional_stats(column),
+            ("nested", false) => (Some(1), Value::Int64(Some(0)), Value::Int64(Some(10))),
+            _ => todo!(),
         };
 
         assert_eq_stats(expected_stats, statistics.unwrap().as_ref());
@@ -378,5 +372,10 @@ pub(crate) mod tests {
     #[test]
     fn pyarrow_v1_non_dict_list_optional() -> Result<()> {
         test_pyarrow_integration("nested", 0, 1, false, false, false)
+    }
+
+    #[test]
+    fn pyarrow_v1_struct_optional() -> Result<()> {
+        test_pyarrow_integration("struct", 0, 1, false, false, false)
     }
 }

--- a/integration-tests/src/read/mod.rs
+++ b/integration-tests/src/read/mod.rs
@@ -149,12 +149,12 @@ pub(crate) mod tests {
         let metadata = read_metadata(reader)?;
 
         let columns = get_column_iterator(reader, &metadata, row_group, field, None, vec![]);
+        let field = &metadata.schema().fields()[field];
 
         let mut statistics = get_field_columns(&metadata, row_group, field)
             .map(|column_meta| column_meta.statistics().transpose())
             .collect::<Result<Vec<_>>>()?;
 
-        let field = &metadata.schema().fields()[field];
         let array = columns_to_array(columns, field)?;
 
         Ok((array, statistics.pop().unwrap()))

--- a/integration-tests/src/read/mod.rs
+++ b/integration-tests/src/read/mod.rs
@@ -15,7 +15,7 @@ use parquet::metadata::ColumnDescriptor;
 use parquet::page::CompressedDataPage;
 use parquet::page::DataPage;
 use parquet::read::BasicDecompressor;
-use parquet::read::MutStreamingIterator;
+use parquet::read::{MutStreamingIterator, State};
 use parquet::schema::types::GroupConvertedType;
 use parquet::schema::types::ParquetType;
 use parquet::schema::types::PhysicalType;
@@ -96,7 +96,7 @@ where
     let mut validity = vec![];
     let mut has_filled = false;
     let mut arrays = vec![];
-    while let Some(mut new_iter) = columns.advance()? {
+    while let State::Some(mut new_iter) = columns.advance()? {
         if let Some((pages, column)) = new_iter.get() {
             let mut iterator = BasicDecompressor::new(pages, vec![]);
             while let Some(page) = iterator.next()? {
@@ -148,7 +148,7 @@ pub(crate) mod tests {
     ) -> Result<(Array, Option<std::sync::Arc<dyn Statistics>>)> {
         let metadata = read_metadata(reader)?;
 
-        let columns = get_column_iterator(reader, &metadata, row_group, field, None);
+        let columns = get_column_iterator(reader, &metadata, row_group, field, None, vec![]);
 
         let mut statistics = get_field_columns(&metadata, row_group, field)
             .map(|column_meta| column_meta.statistics().transpose())

--- a/integration-tests/src/read/struct_.rs
+++ b/integration-tests/src/read/struct_.rs
@@ -1,0 +1,22 @@
+use parquet::encoding::hybrid_rle::HybridRleDecoder;
+use parquet::metadata::ColumnDescriptor;
+use parquet::page::{split_buffer, DataPage};
+use parquet::read::levels::get_bit_width;
+
+pub fn extend_validity(val: &mut Vec<bool>, page: &DataPage, descriptor: &ColumnDescriptor) {
+    let (_, def_levels, _) = split_buffer(page, descriptor);
+    let length = page.num_values();
+
+    if descriptor.max_def_level() == 0 {
+        return;
+    }
+
+    let def_level_encoding = (
+        &page.definition_level_encoding(),
+        descriptor.max_def_level(),
+    );
+
+    let def_levels = HybridRleDecoder::new(def_levels, get_bit_width(def_level_encoding.1), length);
+
+    val.extend(def_levels.map(|x| x != 0));
+}

--- a/src/encoding/bitpacking.rs
+++ b/src/encoding/bitpacking.rs
@@ -45,7 +45,7 @@ pub fn encode_pack(decompressed: [u32; BLOCK_LEN], num_bits: u8, compressed: &mu
     BitPacker1x::new().compress(&decompressed, compressed, num_bits)
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Decoder<'a> {
     compressed_chunks: std::slice::Chunks<'a, u8>,
     num_bits: u8,

--- a/src/encoding/hybrid_rle/mod.rs
+++ b/src/encoding/hybrid_rle/mod.rs
@@ -17,6 +17,7 @@ pub enum HybridEncoded<'a> {
     Rle(&'a [u8], usize),
 }
 
+#[derive(Debug, Clone)]
 enum State<'a> {
     None,
     Bitpacked(bitpacking::Decoder<'a>),
@@ -24,6 +25,7 @@ enum State<'a> {
 }
 
 // Decoder of Hybrid-RLE encoded values.
+#[derive(Debug, Clone)]
 pub struct HybridRleDecoder<'a> {
     decoder: Decoder<'a>,
     state: State<'a>,

--- a/src/read/compression.rs
+++ b/src/read/compression.rs
@@ -134,16 +134,16 @@ fn decompress_reuse<R: std::io::Read>(
 /// * `PageIterator` has its buffer back
 /// * `Decompressor` has its buffer back
 /// * `DecompressedPage` has an empty buffer
-pub struct Decompressor<'a, R: std::io::Read> {
-    iter: PageIterator<'a, R>,
+pub struct Decompressor<R: std::io::Read> {
+    iter: PageIterator<R>,
     buffer: Vec<u8>,
     current: Option<DataPage>,
     was_decompressed: bool,
 }
 
-impl<'a, R: std::io::Read> Decompressor<'a, R> {
+impl<R: std::io::Read> Decompressor<R> {
     /// Creates a new [`Decompressor`].
-    pub fn new(iter: PageIterator<'a, R>, buffer: Vec<u8>) -> Self {
+    pub fn new(iter: PageIterator<R>, buffer: Vec<u8>) -> Self {
         Self {
             iter,
             buffer,
@@ -160,7 +160,7 @@ impl<'a, R: std::io::Read> Decompressor<'a, R> {
     }
 }
 
-impl<'a, R: std::io::Read> FallibleStreamingIterator for Decompressor<'a, R> {
+impl<R: std::io::Read> FallibleStreamingIterator for Decompressor<R> {
     type Item = DataPage;
     type Error = ParquetError;
 

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -19,7 +19,7 @@ pub use page_stream::get_page_stream;
 pub use stream::read_metadata as read_metadata_async;
 
 use crate::error::ParquetError;
-use crate::metadata::{ColumnChunkMetaData, ColumnDescriptor, RowGroupMetaData};
+use crate::metadata::{ColumnChunkMetaData, RowGroupMetaData};
 use crate::{error::Result, metadata::FileMetaData};
 
 /// Filters row group metadata to only those row groups,
@@ -72,7 +72,7 @@ pub struct ColumnIterator<R: Read + Seek> {
     reader: Option<R>,
     columns: Vec<ColumnChunkMetaData>,
     filters: Vec<Option<PageFilter>>,
-    current: Option<(PageIterator<R>, ColumnDescriptor)>,
+    current: Option<(PageIterator<R>, ColumnChunkMetaData)>,
 }
 
 impl<R: Read + Seek> ColumnIterator<R> {
@@ -93,7 +93,7 @@ impl<R: Read + Seek> ColumnIterator<R> {
 }
 
 impl<R: Read + Seek> MutStreamingIterator for ColumnIterator<R> {
-    type Item = (PageIterator<R>, ColumnDescriptor);
+    type Item = (PageIterator<R>, ColumnChunkMetaData);
     type Error = ParquetError;
 
     fn advance(mut self) -> Result<Option<Self>> {
@@ -109,7 +109,7 @@ impl<R: Read + Seek> MutStreamingIterator for ColumnIterator<R> {
         let filter = self.filters.pop().unwrap();
 
         let iter = get_page_iterator(&column, reader, filter, buffer)?;
-        let current = Some((iter, column.descriptor().clone()));
+        let current = Some((iter, column));
         Ok(Some(Self {
             reader: None,
             columns: self.columns,


### PR DESCRIPTION
This PR contains basic APIs to read nested structures from parquet, while keeping the principle of separation of IO-bounded from CPU-bounded operations. In this context, this PR declares an iterator-like trait to support this because it allows users to, as before, collect all the relevant pages of columns and parallelize CPU.

This use-case is interesting from Rust's perspective because it requires an iterator-like (of columns) that returns iterators (of compressed pages), each of them needs to make `.read` calls. This implies that the column iterator must keep ownership of the page iterators so that it can move the reader from iterator to iterator. At the same time, the individual iterators must be mutable so that they can call `.read`.

The API for this:

```rust
pub trait MutStreamingIterator: Sized {
    type Item;
    type Error;

    fn advance(self) -> std::result::Result<Option<Self>, Self::Error>;
    fn get(&mut self) -> Option<&mut Self::Item>;
}
```

which is a variation of a `FallibleStreamingIterator` with the catch that `advance` returns `Option<Self>`. It is expected to be used as 

```rust
let mut iter = ...::new();
while let Some(mut new_iter) = iter.advance()? {
    if let Some(pages) = new_iter.get() {
        for maybe_page in pages {
            let _page = maybe_page?;
        }
    }
    iter = new_iter;  // once we are done with the page iterator, we return the ownership back to `iter`
}
```

as the test shows, the above compiles, which shows the general usability of the principle.