### PR TITLE
Changed stream of groups to stream of futures of groups

### DIFF
--- a/src/write/dyn_iter.rs
+++ b/src/write/dyn_iter.rs
@@ -2,7 +2,7 @@ use crate::FallibleStreamingIterator;
 
 /// [`DynIter`] is an implementation of a single-threaded, dynamically-typed iterator.
 pub struct DynIter<'a, V> {
-    iter: Box<dyn Iterator<Item = V> + 'a>,
+    iter: Box<dyn Iterator<Item = V> + 'a + Send + Sync>,
 }
 
 impl<'a, V> Iterator for DynIter<'a, V> {
@@ -19,7 +19,7 @@ impl<'a, V> Iterator for DynIter<'a, V> {
 impl<'a, V> DynIter<'a, V> {
     pub fn new<I>(iter: I) -> Self
     where
-        I: Iterator<Item = V> + 'a,
+        I: Iterator<Item = V> + 'a + Send + Sync,
     {
         Self {
             iter: Box::new(iter),
@@ -29,7 +29,7 @@ impl<'a, V> DynIter<'a, V> {
 
 /// Dynamically-typed [`FallibleStreamingIterator`].
 pub struct DynStreamingIterator<'a, V, E> {
-    iter: Box<dyn FallibleStreamingIterator<Item = V, Error = E> + 'a>,
+    iter: Box<dyn FallibleStreamingIterator<Item = V, Error = E> + 'a + Send + Sync>,
 }
 
 impl<'a, V, E> FallibleStreamingIterator for DynStreamingIterator<'a, V, E> {
@@ -52,7 +52,7 @@ impl<'a, V, E> FallibleStreamingIterator for DynStreamingIterator<'a, V, E> {
 impl<'a, V, E> DynStreamingIterator<'a, V, E> {
     pub fn new<I>(iter: I) -> Self
     where
-        I: FallibleStreamingIterator<Item = V, Error = E> + 'a,
+        I: FallibleStreamingIterator<Item = V, Error = E> + 'a + Send + Sync,
     {
         Self {
             iter: Box::new(iter),

--- a/src/write/stream.rs
+++ b/src/write/stream.rs
@@ -1,8 +1,9 @@
 use std::io::Write;
 
+use futures::pin_mut;
 use futures::stream::Stream;
+use futures::Future;
 use futures::StreamExt;
-use futures::TryStreamExt;
 
 use parquet_format_async_temp::FileMetaData;
 
@@ -15,7 +16,7 @@ use crate::{
 use super::file::{end_file, start_file};
 use super::{row_group::write_row_group, RowGroupIter, WriteOptions};
 
-pub async fn write_stream<'a, W, S, E>(
+pub async fn write_stream<'a, W, S, E, F>(
     writer: &mut W,
     row_groups: S,
     schema: SchemaDescriptor,
@@ -25,35 +26,35 @@ pub async fn write_stream<'a, W, S, E>(
 ) -> Result<u64>
 where
     W: Write,
-    S: Stream<Item = std::result::Result<RowGroupIter<'a, E>, E>>,
+    F: Future<Output = std::result::Result<RowGroupIter<'a, E>, E>>,
+    S: Stream<Item = F>,
     ParquetError: From<E>,
     E: std::error::Error,
 {
     let mut offset = start_file(writer)? as u64;
 
-    let row_groups = row_groups
-        .map(|row_group| {
-            let (group, size) = write_row_group(
-                writer,
-                offset,
-                schema.columns(),
-                options.compression,
-                row_group?,
-            )?;
-            offset += size;
-            Result::Ok(group)
-        })
-        .try_collect::<Vec<_>>()
-        .await?;
+    let mut groups = vec![];
+    pin_mut!(row_groups);
+    while let Some(row_group) = row_groups.next().await {
+        let (group, size) = write_row_group(
+            writer,
+            offset,
+            schema.columns(),
+            options.compression,
+            row_group.await?,
+        )?;
+        offset += size;
+        groups.push(group);
+    }
 
     // compute file stats
-    let num_rows = row_groups.iter().map(|group| group.num_rows).sum();
+    let num_rows = groups.iter().map(|group| group.num_rows).sum();
 
     let metadata = FileMetaData::new(
         options.version.into(),
         schema.into_thrift()?,
         num_rows,
-        row_groups,
+        groups,
         key_value_metadata,
         created_by,
         None,


### PR DESCRIPTION
When writing stream of row groups, usually computing the stream's item is CPU-bounded and may need to be done in a different thread than the runtime one. However, the access to the next item of the stream may not need to wait for its evaluation.

This means that the values of the stream itself may not be available immediately after the stream yields, and may be available only at a later point in time (when `.await`).

This pattern (stream of futures) is common in Rust (e.g. it is the signature for [`futures::stream.buffered`](https://docs.rs/futures/0.3.18/futures/stream/struct.Buffered.html)), as it allows multiple items from a stream to be evaluated concurrently, since the stream can progress for as long as the consumer can accept running multiple items at the same time.

This PR changes the API to write a stream by allowing the user to give us a stream of futures instead of a stream of values.

To migrate, wrap the value of the stream in `futures::ready(value)` to convert it to a free future