### PR TITLE
Improved performance of reading multiple pages

### DIFF
--- a/src/encoding/mod.rs
+++ b/src/encoding/mod.rs
@@ -13,6 +13,7 @@ pub use crate::parquet_bridge::Encoding;
 
 /// # Panics
 /// This function panics iff `values.len() < 4`.
+#[inline]
 pub fn get_length(values: &[u8]) -> u32 {
     u32::from_le_bytes(values[0..4].try_into().unwrap())
 }

--- a/src/read/compression.rs
+++ b/src/read/compression.rs
@@ -50,8 +50,13 @@ pub fn decompress_buffer(
         let compressed_buffer = &compressed_page.buffer;
 
         // prepare the compression buffer
-        buffer.clear();
-        buffer.resize(compressed_page.uncompressed_size(), 0);
+        let read_size = compressed_page.uncompressed_size();
+        if read_size > buffer.len() {
+            // dealloc and ignore region, replacing it by a new region
+            *buffer = vec![0; read_size]
+        } else {
+            buffer.truncate(read_size);
+        }
         match compressed_page.header() {
             DataPageHeader::V1(_) => {
                 decompress_v1(compressed_buffer, compressed_page.compression(), buffer)?

--- a/src/read/page_iterator.rs
+++ b/src/read/page_iterator.rs
@@ -137,8 +137,12 @@ fn build_page<R: Read>(
 
     let read_size = page_header.compressed_page_size as usize;
     if read_size > 0 {
-        buffer.clear();
-        buffer.resize(read_size, 0);
+        if read_size > buffer.len() {
+            // dealloc and ignore region, replacing it by a new region
+            *buffer = vec![0; read_size]
+        } else {
+            buffer.truncate(read_size);
+        }
         reader.reader.read_exact(buffer)?;
     }
 


### PR DESCRIPTION
This PR improves buffer reuse by avoiding a memcopy of data that is about to be re-written.

Performance downstream (`arrow2`)

```
read utf8 multi 2^20    time:   [7.2616 ms 7.3060 ms 7.3530 ms]                                 
                        change: [-17.488% -16.369% -15.395%] (p = 0.00 < 0.05)
```