### PR TITLE
Add constructor to RowGroupMetaData and ColumnChunkMetaData

### DIFF
--- a/src/metadata/column_chunk_metadata.rs
+++ b/src/metadata/column_chunk_metadata.rs
@@ -20,6 +20,14 @@ pub struct ColumnChunkMetaData {
 
 /// Represents common operations for a column chunk.
 impl ColumnChunkMetaData {
+    /// Create a new [`ColumnChunkMetaData`]
+    pub fn new(column_chunk: ColumnChunk, column_descr: ColumnDescriptor) -> Self {
+        Self {
+            column_chunk,
+            column_descr,
+        }
+    }
+
     /// File where the column chunk is stored.
     ///
     /// If not set, assumed to belong to the same file as the metadata.

--- a/src/metadata/row_metadata.rs
+++ b/src/metadata/row_metadata.rs
@@ -12,6 +12,19 @@ pub struct RowGroupMetaData {
 }
 
 impl RowGroupMetaData {
+    /// Create a new [`RowGroupMetaData`]
+    pub fn new(
+        columns: Vec<ColumnChunkMetaData>,
+        num_rows: i64,
+        total_byte_size: i64,
+    ) -> RowGroupMetaData {
+        Self {
+            columns,
+            num_rows,
+            total_byte_size,
+        }
+    }
+
     /// Number of columns in this row group.
     pub fn num_columns(&self) -> usize {
         self.columns.len()


### PR DESCRIPTION
To create metadata and construct tests for filter push down in DataFusion