### PR TITLE
Update zstd dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ snap = { version = "^1.0", optional = true }
 brotli = { version = "^3.3", optional = true }
 flate2 = { version = "^1.0", optional = true }
 lz4 = { version = "^1.23", optional = true }
-zstd = { version = "^0.9", optional = true }
+zstd = { version = "^0.10", optional = true }
 
 [features]
 default = ["snappy", "gzip", "lz4", "zstd", "brotli", "stream"]


### PR DESCRIPTION
Update zstd to 0.10.

This is the same version that is currently used in [arrow-rs/parquet](https://github.com/apache/arrow-rs/blob/39f3f711876ff113545b1a2d7023f66de77bb731/parquet/Cargo.toml#L40) and would allow having both as a dependency, for example to compare performance.