### PR TITLE
Implemented `bytemuck::Pod` to `NativeType`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ name = "parquet2"
 bench = false
 
 [dependencies]
+bytemuck = { version = "1", features = ["derive"] }
+
 parquet-format-async-temp = "0.2.0"
 bitpacking = { version = "0.8.2", features = ["bitpacker1x"] }
 streaming-decompression = "0.1"

--- a/src/encoding/delta_bitpacked/decoder.rs
+++ b/src/encoding/delta_bitpacked/decoder.rs
@@ -106,7 +106,6 @@ impl<'a> Iterator for Block<'a> {
 /// This struct does not allocate on the heap.
 #[derive(Debug)]
 pub struct Decoder<'a> {
-    block_size: u64,
     num_mini_blocks: usize,
     values_per_mini_block: usize,
     values_remaining: usize,
@@ -152,7 +151,6 @@ impl<'a> Decoder<'a> {
         };
 
         Self {
-            block_size,
             num_mini_blocks,
             values_per_mini_block,
             values_remaining: total_count,

--- a/src/page/page_dict/primitive.rs
+++ b/src/page/page_dict/primitive.rs
@@ -32,9 +32,8 @@ impl<T: NativeType> DictPage for PrimitivePageDict<T> {
 
 fn read_plain<T: NativeType>(values: &[u8]) -> Vec<T> {
     // read in plain
-    let chunks = values.chunks_exact(std::mem::size_of::<T>());
-    assert_eq!(chunks.remainder().len(), 0);
-    chunks.map(|chunk| types::decode(chunk)).collect()
+    assert_eq!(values.len() % std::mem::size_of::<T>(), 0);
+    types::decode(values).to_vec()
 }
 
 pub fn read<T: NativeType>(

--- a/src/statistics/primitive.rs
+++ b/src/statistics/primitive.rs
@@ -56,8 +56,8 @@ pub fn read<T: types::NativeType>(
         descriptor,
         null_count: v.null_count,
         distinct_count: v.distinct_count,
-        max_value: v.max_value.as_ref().map(|x| types::decode(x)),
-        min_value: v.min_value.as_ref().map(|x| types::decode(x)),
+        max_value: v.max_value.as_ref().map(|x| types::decode(x)[0]),
+        min_value: v.min_value.as_ref().map(|x| types::decode(x)[0]),
     }))
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,9 +1,11 @@
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryFrom;
+
+use bytemuck::Pod;
 
 use crate::schema::types::PhysicalType;
 
 /// A physical native representation of a Parquet fixed-sized type.
-pub trait NativeType: Sized + Copy + std::fmt::Debug + Send + Sync + 'static {
+pub trait NativeType: std::fmt::Debug + Send + Sync + Pod {
     type Bytes: AsRef<[u8]> + for<'a> TryFrom<&'a [u8]>;
 
     fn to_le_bytes(&self) -> Self::Bytes;
@@ -99,6 +101,7 @@ impl NativeType for [u32; 3] {
     }
 }
 
+#[inline]
 pub fn int96_to_i64_ns(value: [u32; 3]) -> i64 {
     const JULIAN_DAY_OF_EPOCH: i64 = 2_440_588;
     const SECONDS_PER_DAY: i64 = 86_400;
@@ -112,10 +115,6 @@ pub fn int96_to_i64_ns(value: [u32; 3]) -> i64 {
 }
 
 #[inline]
-pub fn decode<T: NativeType>(chunk: &[u8]) -> T {
-    let chunk: <T as NativeType>::Bytes = match chunk.try_into() {
-        Ok(v) => v,
-        Err(_) => panic!(),
-    };
-    T::from_le_bytes(chunk)
+pub fn decode<T: NativeType>(chunk: &[u8]) -> &[T] {
+    bytemuck::cast_slice(chunk)
 }


### PR DESCRIPTION
This allows users to map `&[u8] -> &[T]` without an iterator.