### PR TITLE
refactor serialization/io of thrift structures with trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ parquet-format-async-temp = "0.2.0"
 bitpacking = { version = "0.8.2", features = ["bitpacker1x"] }
 streaming-decompression = "0.1"
 
+async-trait = "0.1.52"
 async-stream = { version = "0.3.2", optional = true }
 futures = { version = "0.3", optional = true }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ mod parquet_bridge;
 pub mod read;
 pub mod schema;
 pub mod statistics;
+mod thrift_io_wrapper;
 pub mod types;
 pub mod write;
 

--- a/src/read/page_iterator.rs
+++ b/src/read/page_iterator.rs
@@ -1,11 +1,10 @@
 use std::convert::TryInto;
 use std::{io::Read, sync::Arc};
 
-use parquet_format_async_temp::thrift::protocol::TCompactInputProtocol;
-
 use crate::compression::Compression;
 use crate::error::Result;
 use crate::metadata::ColumnDescriptor;
+use crate::thrift_io_wrapper::ThriftReader;
 
 use crate::page::{
     read_dict_page, CompressedDataPage, DataPageHeader, DictPage, EncodedDictPage, PageType,
@@ -63,9 +62,7 @@ impl<R: Read> PageIterator<R> {
 
     /// Reads Page header from Thrift.
     fn read_page_header(&mut self) -> Result<ParquetPageHeader> {
-        let mut prot = TCompactInputProtocol::new(&mut self.reader);
-        let page_header = ParquetPageHeader::read_from_in_protocol(&mut prot)?;
-        Ok(page_header)
+        ParquetPageHeader::read_thrift_from(&mut self.reader)
     }
 
     pub fn reuse_buffer(&mut self, buffer: Vec<u8>) {

--- a/src/read/page_iterator.rs
+++ b/src/read/page_iterator.rs
@@ -4,7 +4,7 @@ use std::{io::Read, sync::Arc};
 use crate::compression::Compression;
 use crate::error::Result;
 use crate::metadata::ColumnDescriptor;
-use crate::thrift_io_wrapper::ThriftReader;
+use crate::thrift_io_wrapper::read_from_thrift;
 
 use crate::page::{
     read_dict_page, CompressedDataPage, DataPageHeader, DictPage, EncodedDictPage, PageType,
@@ -62,7 +62,7 @@ impl<R: Read> PageIterator<R> {
 
     /// Reads Page header from Thrift.
     fn read_page_header(&mut self) -> Result<ParquetPageHeader> {
-        ParquetPageHeader::read_thrift_from(&mut self.reader)
+        read_from_thrift(&mut self.reader)
     }
 
     pub fn reuse_buffer(&mut self, buffer: Vec<u8>) {

--- a/src/read/page_stream.rs
+++ b/src/read/page_stream.rs
@@ -6,11 +6,11 @@ use futures::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt, Stream};
 use crate::compression::Compression;
 use crate::error::Result;
 use crate::metadata::{ColumnChunkMetaData, ColumnDescriptor};
-use crate::page::{CompressedDataPage, ParquetPageHeader};
+use crate::page::CompressedDataPage;
 
 use super::page_iterator::{finish_page, get_page_header, FinishedPage};
 use super::PageFilter;
-use crate::thrift_io_wrapper::ThriftReader;
+use crate::thrift_io_wrapper::read_from_thrift_async;
 
 /// Returns a stream of compressed data pages
 pub async fn get_page_stream<'a, RR: AsyncRead + Unpin + Send + AsyncSeek>(
@@ -44,7 +44,7 @@ fn _get_page_stream<'a, R: AsyncRead + AsyncSeek + Unpin + Send>(
     try_stream! {
         while seen_values < total_num_values {
             // the header
-            let page_header = ParquetPageHeader::read_thrift_from_async(reader).await?;
+            let page_header = read_from_thrift_async(reader).await?;
 
             let data_header = get_page_header(&page_header);
             seen_values += data_header.as_ref().map(|x| x.num_values() as i64).unwrap_or_default();

--- a/src/thrift_io_wrapper.rs
+++ b/src/thrift_io_wrapper.rs
@@ -3,60 +3,53 @@ use async_trait::async_trait;
 use futures::{AsyncRead, AsyncWrite};
 use parquet_format_async_temp::thrift::protocol::{
     TCompactInputProtocol, TCompactInputStreamProtocol, TCompactOutputProtocol,
-    TCompactOutputStreamProtocol, TOutputProtocol, TOutputStreamProtocol,
+    TCompactOutputStreamProtocol, TInputProtocol, TInputStreamProtocol, TOutputProtocol,
+    TOutputStreamProtocol,
 };
+use parquet_format_async_temp::thrift::Result as ThriftResult;
 use parquet_format_async_temp::{ColumnChunk, FileMetaData, PageHeader};
 use std::io::{Read, Write};
 
 #[async_trait]
-pub trait ThriftReader: Sized {
-    fn read_thrift_from<R: Read>(reader: &mut R) -> Result<Self>;
-    async fn read_thrift_from_async<R: AsyncRead + Unpin + Send>(reader: &mut R) -> Result<Self>;
-}
+pub trait ThriftType: Sized {
+    fn write_to_out_protocol(&self, o_prot: &mut dyn TOutputProtocol) -> ThriftResult<usize>;
 
-#[async_trait]
-pub trait ThriftWriter: Sized {
-    fn write_thrift_to<W: Write>(&self, writer: &mut W) -> Result<usize>;
-    async fn write_thrift_to_async<W: AsyncWrite + Unpin + Send>(
+    async fn write_to_out_stream_protocol(
         &self,
-        writer: &mut W,
-    ) -> Result<usize>;
+        o_prot: &mut dyn TOutputStreamProtocol,
+    ) -> ThriftResult<usize>;
+
+    fn read_from_in_protocol(i_prot: &mut dyn TInputProtocol) -> ThriftResult<Self>;
+
+    async fn stream_from_in_protocol(i_prot: &mut dyn TInputStreamProtocol) -> ThriftResult<Self>;
 }
 
 macro_rules! define_thrift_impl {
-    ( $typ:ty ) => {
+    ( $type:ty ) => {
         #[async_trait]
-        impl ThriftReader for $typ {
-            fn read_thrift_from<R: Read>(reader: &mut R) -> Result<Self> {
-                let mut protocol = TCompactInputProtocol::new(reader);
-                let value = <$typ>::read_from_in_protocol(&mut protocol)?;
-                Ok(value)
-            }
-            async fn read_thrift_from_async<R: AsyncRead + Unpin + Send>(
-                reader: &mut R,
-            ) -> Result<Self> {
-                let mut prot = TCompactInputStreamProtocol::new(reader);
-                Ok(<$typ>::stream_from_in_protocol(&mut prot).await?)
-            }
-        }
-
-        #[async_trait]
-        impl ThriftWriter for $typ {
-            async fn write_thrift_to_async<W: AsyncWrite + Unpin + Send>(
+        impl ThriftType for $type {
+            fn write_to_out_protocol(
                 &self,
-                writer: &mut W,
-            ) -> Result<usize> {
-                let mut protocol = TCompactOutputStreamProtocol::new(writer);
-                let n = self.write_to_out_stream_protocol(&mut protocol).await?;
-                protocol.flush().await?;
-                Ok(n)
+                o_prot: &mut dyn TOutputProtocol,
+            ) -> ThriftResult<usize> {
+                self.write_to_out_protocol(o_prot)
             }
 
-            fn write_thrift_to<W: Write>(&self, writer: &mut W) -> Result<usize> {
-                let mut protocol = TCompactOutputProtocol::new(writer);
-                let n = self.write_to_out_protocol(&mut protocol)?;
-                protocol.flush()?;
-                Ok(n)
+            async fn write_to_out_stream_protocol(
+                &self,
+                o_prot: &mut dyn TOutputStreamProtocol,
+            ) -> ThriftResult<usize> {
+                self.write_to_out_stream_protocol(o_prot).await
+            }
+
+            fn read_from_in_protocol(i_prot: &mut dyn TInputProtocol) -> ThriftResult<Self> {
+                <$type>::read_from_in_protocol(i_prot)
+            }
+
+            async fn stream_from_in_protocol(
+                i_prot: &mut dyn TInputStreamProtocol,
+            ) -> ThriftResult<Self> {
+                <$type>::stream_from_in_protocol(i_prot).await
             }
         }
     };
@@ -65,3 +58,33 @@ macro_rules! define_thrift_impl {
 define_thrift_impl!(PageHeader);
 define_thrift_impl!(ColumnChunk);
 define_thrift_impl!(FileMetaData);
+
+pub fn read_from_thrift<T: ThriftType, R: Read>(reader: &mut R) -> Result<T> {
+    let mut protocol = TCompactInputProtocol::new(reader);
+    let value = T::read_from_in_protocol(&mut protocol)?;
+    Ok(value)
+}
+
+pub async fn read_from_thrift_async<T: ThriftType, R: AsyncRead + Unpin + Send>(
+    reader: &mut R,
+) -> Result<T> {
+    let mut prot = TCompactInputStreamProtocol::new(reader);
+    Ok(T::stream_from_in_protocol(&mut prot).await?)
+}
+
+pub fn write_to_thrift<T: ThriftType, W: Write>(value: &T, writer: &mut W) -> Result<usize> {
+    let mut protocol = TCompactOutputProtocol::new(writer);
+    let r = value.write_to_out_protocol(&mut protocol)?;
+    protocol.flush()?;
+    Ok(r)
+}
+
+pub async fn write_to_thrift_async<T: ThriftType, W: AsyncWrite + Unpin + Send>(
+    value: &T,
+    writer: &mut W,
+) -> Result<usize> {
+    let mut protocol = TCompactOutputStreamProtocol::new(writer);
+    let r = value.write_to_out_stream_protocol(&mut protocol).await?;
+    protocol.flush().await?;
+    Ok(r)
+}

--- a/src/thrift_io_wrapper.rs
+++ b/src/thrift_io_wrapper.rs
@@ -1,0 +1,67 @@
+use crate::error::Result;
+use async_trait::async_trait;
+use futures::{AsyncRead, AsyncWrite};
+use parquet_format_async_temp::thrift::protocol::{
+    TCompactInputProtocol, TCompactInputStreamProtocol, TCompactOutputProtocol,
+    TCompactOutputStreamProtocol, TOutputProtocol, TOutputStreamProtocol,
+};
+use parquet_format_async_temp::{ColumnChunk, FileMetaData, PageHeader};
+use std::io::{Read, Write};
+
+#[async_trait]
+pub trait ThriftReader: Sized {
+    fn read_thrift_from<R: Read>(reader: &mut R) -> Result<Self>;
+    async fn read_thrift_from_async<R: AsyncRead + Unpin + Send>(reader: &mut R) -> Result<Self>;
+}
+
+#[async_trait]
+pub trait ThriftWriter: Sized {
+    fn write_thrift_to<W: Write>(&self, writer: &mut W) -> Result<usize>;
+    async fn write_thrift_to_async<W: AsyncWrite + Unpin + Send>(
+        &self,
+        writer: &mut W,
+    ) -> Result<usize>;
+}
+
+macro_rules! define_thrift_impl {
+    ( $typ:ty ) => {
+        #[async_trait]
+        impl ThriftReader for $typ {
+            fn read_thrift_from<R: Read>(reader: &mut R) -> Result<Self> {
+                let mut protocol = TCompactInputProtocol::new(reader);
+                let value = <$typ>::read_from_in_protocol(&mut protocol)?;
+                Ok(value)
+            }
+            async fn read_thrift_from_async<R: AsyncRead + Unpin + Send>(
+                reader: &mut R,
+            ) -> Result<Self> {
+                let mut prot = TCompactInputStreamProtocol::new(reader);
+                Ok(<$typ>::stream_from_in_protocol(&mut prot).await?)
+            }
+        }
+
+        #[async_trait]
+        impl ThriftWriter for $typ {
+            async fn write_thrift_to_async<W: AsyncWrite + Unpin + Send>(
+                &self,
+                writer: &mut W,
+            ) -> Result<usize> {
+                let mut protocol = TCompactOutputStreamProtocol::new(writer);
+                let n = self.write_to_out_stream_protocol(&mut protocol).await?;
+                protocol.flush().await?;
+                Ok(n)
+            }
+
+            fn write_thrift_to<W: Write>(&self, writer: &mut W) -> Result<usize> {
+                let mut protocol = TCompactOutputProtocol::new(writer);
+                let n = self.write_to_out_protocol(&mut protocol)?;
+                protocol.flush()?;
+                Ok(n)
+            }
+        }
+    };
+}
+
+define_thrift_impl!(PageHeader);
+define_thrift_impl!(ColumnChunk);
+define_thrift_impl!(FileMetaData);

--- a/src/thrift_io_wrapper.rs
+++ b/src/thrift_io_wrapper.rs
@@ -75,7 +75,6 @@ pub async fn read_from_thrift_async<T: ThriftType, R: AsyncRead + Unpin + Send>(
 pub fn write_to_thrift<T: ThriftType, W: Write>(value: &T, writer: &mut W) -> Result<usize> {
     let mut protocol = TCompactOutputProtocol::new(writer);
     let r = value.write_to_out_protocol(&mut protocol)?;
-    protocol.flush()?;
     Ok(r)
 }
 
@@ -85,6 +84,5 @@ pub async fn write_to_thrift_async<T: ThriftType, W: AsyncWrite + Unpin + Send>(
 ) -> Result<usize> {
     let mut protocol = TCompactOutputStreamProtocol::new(writer);
     let r = value.write_to_out_stream_protocol(&mut protocol).await?;
-    protocol.flush().await?;
     Ok(r)
 }

--- a/src/write/column_chunk.rs
+++ b/src/write/column_chunk.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 use std::convert::TryInto;
 use std::io::Write;
 
-use crate::thrift_io_wrapper::ThriftWriter;
+use crate::thrift_io_wrapper::{write_to_thrift, write_to_thrift_async};
 use futures::AsyncWrite;
 use parquet_format_async_temp::{ColumnChunk, ColumnMetaData};
 
@@ -47,7 +47,7 @@ where
 
     let column_chunk = build_column_chunk(&specs, descriptor, compression)?;
 
-    column_chunk.write_thrift_to(writer)?;
+    write_to_thrift(&column_chunk, writer)?;
 
     Ok((column_chunk, bytes_written))
 }
@@ -76,7 +76,7 @@ where
 
     let column_chunk = build_column_chunk(&specs, descriptor, compression)?;
     // write metadata
-    column_chunk.write_thrift_to_async(writer).await?;
+    write_to_thrift_async(&column_chunk, writer).await?;
     Ok((column_chunk, bytes_written))
 }
 

--- a/src/write/file.rs
+++ b/src/write/file.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 
 use parquet_format_async_temp::FileMetaData;
 
-use crate::thrift_io_wrapper::ThriftWriter;
+use crate::thrift_io_wrapper::write_to_thrift;
 use parquet_format_async_temp::RowGroup;
 
 pub use crate::metadata::KeyValue;
@@ -21,7 +21,7 @@ pub(super) fn start_file<W: Write>(writer: &mut W) -> Result<u64> {
 
 pub(super) fn end_file<W: Write>(writer: &mut W, metadata: FileMetaData) -> Result<u64> {
     // Write metadata
-    let metadata_len = metadata.write_thrift_to(writer)?;
+    let metadata_len = write_to_thrift(&metadata, writer)?;
 
     // Write footer
     let metadata_bytes = metadata_len.to_le_bytes();

--- a/src/write/file.rs
+++ b/src/write/file.rs
@@ -2,8 +2,7 @@ use std::io::Write;
 
 use parquet_format_async_temp::FileMetaData;
 
-use parquet_format_async_temp::thrift::protocol::TCompactOutputProtocol;
-use parquet_format_async_temp::thrift::protocol::TOutputProtocol;
+use crate::thrift_io_wrapper::ThriftWriter;
 use parquet_format_async_temp::RowGroup;
 
 pub use crate::metadata::KeyValue;
@@ -20,11 +19,9 @@ pub(super) fn start_file<W: Write>(writer: &mut W) -> Result<u64> {
     Ok(PARQUET_MAGIC.len() as u64)
 }
 
-pub(super) fn end_file<W: Write>(mut writer: &mut W, metadata: FileMetaData) -> Result<u64> {
+pub(super) fn end_file<W: Write>(writer: &mut W, metadata: FileMetaData) -> Result<u64> {
     // Write metadata
-    let mut protocol = TCompactOutputProtocol::new(&mut writer);
-    let metadata_len = metadata.write_to_out_protocol(&mut protocol)? as i32;
-    protocol.flush()?;
+    let metadata_len = metadata.write_thrift_to(writer)?;
 
     // Write footer
     let metadata_bytes = metadata_len.to_le_bytes();

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -6,7 +6,7 @@ mod row_group;
 pub(self) mod statistics;
 
 #[cfg(feature = "stream")]
-mod stream;
+pub mod stream;
 #[cfg(feature = "stream")]
 pub use stream::FileStreamer;
 

--- a/src/write/page.rs
+++ b/src/write/page.rs
@@ -10,7 +10,7 @@ use crate::page::{
     CompressedDataPage, CompressedDictPage, CompressedPage, DataPageHeader, ParquetPageHeader,
 };
 use crate::statistics::Statistics;
-use crate::thrift_io_wrapper::ThriftWriter;
+use crate::thrift_io_wrapper::{write_to_thrift, write_to_thrift_async};
 
 fn maybe_bytes(uncompressed: usize, compressed: usize) -> Result<(i32, i32)> {
     let uncompressed_page_size: i32 = uncompressed.try_into().map_err(|_| {
@@ -49,7 +49,7 @@ pub fn write_page<W: Write>(
         CompressedPage::Dict(compressed_page) => assemble_dict_page_header(compressed_page),
     }?;
 
-    let header_size = header.write_thrift_to(writer)? as u64;
+    let header_size = write_to_thrift(&header, writer)? as u64;
     let mut bytes_written = header_size;
 
     bytes_written += match &compressed_page {
@@ -87,7 +87,7 @@ pub async fn write_page_async<W: AsyncWrite + Unpin + Send>(
         CompressedPage::Dict(compressed_page) => assemble_dict_page_header(compressed_page),
     }?;
 
-    let header_size = header.write_thrift_to_async(writer).await? as u64;
+    let header_size = write_to_thrift_async(&header, writer).await? as u64;
     let mut bytes_written = header_size as u64;
 
     bytes_written += match &compressed_page {

--- a/src/write/stream.rs
+++ b/src/write/stream.rs
@@ -4,7 +4,8 @@ use futures::{AsyncWrite, AsyncWriteExt};
 
 use parquet_format_async_temp::{FileMetaData, RowGroup};
 
-use crate::thrift_io_wrapper::ThriftWriter;
+use crate::thrift_io_wrapper::write_to_thrift_async;
+
 use crate::{
     error::{ParquetError, Result},
     metadata::{KeyValue, SchemaDescriptor},
@@ -23,7 +24,7 @@ async fn end_file<W: AsyncWrite + Unpin + Send>(
     metadata: FileMetaData,
 ) -> Result<u64> {
     // Write file metadata
-    let metadata_len = metadata.write_thrift_to_async(writer).await? as i32;
+    let metadata_len = write_to_thrift_async(&metadata, writer).await? as i32;
 
     // Write footer
     let metadata_bytes = metadata_len.to_le_bytes();


### PR DESCRIPTION
there are too many boilerplate codes to read/write thrift structs.
and will be more when other features are added.
