### PR TITLE
WIP: Use lz4_flex for `wasm32`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,7 @@ jobs:
           export CARGO_HOME="/github/home/.cargo"
           export CARGO_TARGET_DIR="/github/home/target"
           cargo test
+          cargo test --no-default-features --features snappy --features gzip --features lz4_flex --features zstd --features brotli --features stream
       - name: Setup parquet files
         run: |
           apt update && apt install python3-pip python3-venv -y -q

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,18 +24,10 @@ brotli = { version = "^3.3", optional = true }
 flate2 = { version = "^1.0", optional = true }
 lz4 = { version = "^1.23", optional = true }
 zstd = { version = "^0.11", optional = true, default-features = false }
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
 lz4_flex = { version = "^0.9.2", optional = true }
-
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-lz4 = { version = "^1.23", optional = true }
 
 [features]
 default = ["snappy", "gzip", "lz4", "zstd", "brotli", "stream"]
 snappy = ["snap"]
 gzip = ["flate2"]
 stream = ["futures", "async-stream"]
-
-[target.'cfg(target_arch = "wasm32")'.features]
-lz4 = ["lz4_flex"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,12 +22,19 @@ futures = { version = "0.3", optional = true }
 snap = { version = "^1.0", optional = true }
 brotli = { version = "^3.3", optional = true }
 flate2 = { version = "^1.0", optional = true }
-lz4_flex = { version = "^0.9.2", optional = true }
 zstd = { version = "^0.10", optional = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+lz4_flex = { version = "^0.9.2", optional = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+lz4 = { version = "^1.23", optional = true }
 
 [features]
 default = ["snappy", "gzip", "lz4", "zstd", "brotli", "stream"]
 snappy = ["snap"]
 gzip = ["flate2"]
-lz4 = ["lz4_flex"]
 stream = ["futures", "async-stream"]
+
+[target.'cfg(target_arch = "wasm32")'.features]
+lz4 = ["lz4_flex"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,12 @@ futures = { version = "0.3", optional = true }
 snap = { version = "^1.0", optional = true }
 brotli = { version = "^3.3", optional = true }
 flate2 = { version = "^1.0", optional = true }
-lz4 = { version = "^1.23", optional = true }
+lz4_flex = { version = "^0.9.2", optional = true }
 zstd = { version = "^0.10", optional = true }
 
 [features]
 default = ["snappy", "gzip", "lz4", "zstd", "brotli", "stream"]
 snappy = ["snap"]
 gzip = ["flate2"]
+lz4 = ["lz4_flex"]
 stream = ["futures", "async-stream"]

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -61,7 +61,7 @@ pub fn compress(
             crate::error::Feature::Snappy,
             "compress to snappy".to_string(),
         )),
-        #[cfg(feature = "lz4")]
+        #[cfg(all(feature = "lz4", target_arch = "wasm32"))]
         Compression::Lz4 => {
             use std::io::Write;
             const LZ4_BUFFER_SIZE: usize = 4096;
@@ -77,6 +77,22 @@ pub fn compress(
             }
             encoder.finish().unwrap();
             Ok(())
+        }
+        #[cfg(all(feature = "lz4", not(target_arch = "wasm32")))]
+        Compression::Lz4 => {
+            use std::io::Write;
+            const LZ4_BUFFER_SIZE: usize = 4096;
+            let mut encoder = lz4::EncoderBuilder::new().build(output_buf)?;
+            let mut from = 0;
+            loop {
+                let to = std::cmp::min(from + LZ4_BUFFER_SIZE, input_buf.len());
+                encoder.write_all(&input_buf[from..to])?;
+                from += LZ4_BUFFER_SIZE;
+                if from >= input_buf.len() {
+                    break;
+                }
+            }
+            encoder.finish().1.map_err(|e| e.into())
         }
         #[cfg(not(feature = "lz4"))]
         Compression::Lz4 => Err(ParquetError::FeatureNotActive(
@@ -155,10 +171,16 @@ pub fn decompress(compression: Compression, input_buf: &[u8], output_buf: &mut [
             crate::error::Feature::Snappy,
             "decompress with snappy".to_string(),
         )),
-        #[cfg(feature = "lz4")]
+        #[cfg(all(feature = "lz4", target_arch = "wasm32"))]
         Compression::Lz4 => {
             use std::io::Read;
             let mut decoder = lz4_flex::frame::FrameDecoder::new(input_buf);
+            decoder.read_exact(output_buf).map_err(|e| e.into())
+        }
+        #[cfg(all(feature = "lz4", not(target_arch = "wasm32")))]
+        Compression::Lz4 => {
+            use std::io::Read;
+            let mut decoder = lz4::Decoder::new(input_buf)?;
             decoder.read_exact(output_buf).map_err(|e| e.into())
         }
         #[cfg(not(feature = "lz4"))]

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -61,7 +61,7 @@ pub fn compress(
             crate::error::Feature::Snappy,
             "compress to snappy".to_string(),
         )),
-        #[cfg(all(feature = "lz4", target_arch = "wasm32"))]
+        #[cfg(all(feature = "lz4_flex", not(feature = "lz4")))]
         Compression::Lz4 => {
             use std::io::Write;
             const LZ4_BUFFER_SIZE: usize = 4096;
@@ -78,7 +78,7 @@ pub fn compress(
             encoder.finish().unwrap();
             Ok(())
         }
-        #[cfg(all(feature = "lz4", not(target_arch = "wasm32")))]
+        #[cfg(feature = "lz4")]
         Compression::Lz4 => {
             use std::io::Write;
             const LZ4_BUFFER_SIZE: usize = 4096;
@@ -94,7 +94,7 @@ pub fn compress(
             }
             encoder.finish().1.map_err(|e| e.into())
         }
-        #[cfg(not(feature = "lz4"))]
+        #[cfg(all(not(feature = "lz4"), not(feature = "lz4_flex")))]
         Compression::Lz4 => Err(ParquetError::FeatureNotActive(
             crate::error::Feature::Lz4,
             "compress to lz4".to_string(),
@@ -171,19 +171,19 @@ pub fn decompress(compression: Compression, input_buf: &[u8], output_buf: &mut [
             crate::error::Feature::Snappy,
             "decompress with snappy".to_string(),
         )),
-        #[cfg(all(feature = "lz4", target_arch = "wasm32"))]
+        #[cfg(all(feature = "lz4_flex", not(feature = "lz4")))]
         Compression::Lz4 => {
             use std::io::Read;
             let mut decoder = lz4_flex::frame::FrameDecoder::new(input_buf);
             decoder.read_exact(output_buf).map_err(|e| e.into())
         }
-        #[cfg(all(feature = "lz4", not(target_arch = "wasm32")))]
+        #[cfg(feature = "lz4")]
         Compression::Lz4 => {
             use std::io::Read;
             let mut decoder = lz4::Decoder::new(input_buf)?;
             decoder.read_exact(output_buf).map_err(|e| e.into())
         }
-        #[cfg(not(feature = "lz4"))]
+        #[cfg(all(not(feature = "lz4"), not(feature = "lz4_flex")))]
         Compression::Lz4 => Err(ParquetError::FeatureNotActive(
             crate::error::Feature::Lz4,
             "decompress with lz4".to_string(),


### PR DESCRIPTION
Disclaimer: I'm new to Rust but motivated to get LZ4 Parquet decompression working in wasm. 🙂 

I'm working on [wasm bindings](https://github.com/kylebarron/parquet-wasm) to `arrow2`/`parquet2`. So far it appears that all other compressions other than LZ4 are working. I tried to switch to `lz4_flex` on this branch but I'm not sure I gated the wasm target correctly. Tests seem to pass on this branch but when I try to load a Parquet file with LZ4 encoding on the web I get an error `Uncaught (in promise) External format error: underlying IO error: WrongMagicNumber`. Maybe I'm using the wrong `lz4_flex` APIs.

Ref #85 