### PR TITLE
Update zstd version for wasm support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ snap = { version = "^1.0", optional = true }
 brotli = { version = "^3.3", optional = true }
 flate2 = { version = "^1.0", optional = true }
 lz4 = { version = "^1.23", optional = true }
-zstd = { version = "^0.10", optional = true }
+zstd = { version = "^0.11", optional = true, default-features = false }
 
 [features]
 default = ["snappy", "gzip", "lz4", "zstd", "brotli", "stream"]


### PR DESCRIPTION
zstd has released [version 0.11](https://github.com/gyscos/zstd-rs/releases/tag/v0.11.0) with Web Assembly support https://github.com/gyscos/zstd-rs/pull/139.