### PR TITLE
Added `ordinal` and `total_compressed_size` to column meta

### DIFF
--- a/integration-tests/src/read/mod.rs
+++ b/integration-tests/src/read/mod.rs
@@ -148,6 +148,10 @@ pub(crate) mod tests {
     ) -> Result<(Array, Option<std::sync::Arc<dyn Statistics>>)> {
         let metadata = read_metadata(reader)?;
 
+        let expected = metadata.row_groups[0].column(0).compressed_size();
+        let chunk = metadata.row_groups[0].column(0).clone().into_thrift();
+        assert_eq!(chunk.meta_data.unwrap().total_compressed_size, expected);
+
         let columns = get_column_iterator(reader, &metadata, row_group, field, None, vec![]);
         let field = &metadata.schema().fields()[field];
 

--- a/src/encoding/delta_bitpacked/encoder.rs
+++ b/src/encoding/delta_bitpacked/encoder.rs
@@ -27,7 +27,7 @@ pub fn encode<I: Iterator<Item = i64>>(mut iterator: I, buffer: &mut Vec<u8>) {
     let mut values = [0i64; 128];
     let mut deltas = [0u32; 128];
 
-    let first_value = iterator.next().unwrap().into();
+    let first_value = iterator.next().unwrap();
     let (container, encoded_len) = zigzag_leb128::encode(first_value);
     buffer.extend_from_slice(&container[..encoded_len]);
 
@@ -35,7 +35,6 @@ pub fn encode<I: Iterator<Item = i64>>(mut iterator: I, buffer: &mut Vec<u8>) {
     let mut length = iterator.size_hint().1.unwrap();
     while length != 0 {
         for (i, v) in (0..128).zip(&mut iterator) {
-            let v: i64 = v.into();
             values[i] = v - prev;
             prev = v;
         }

--- a/src/metadata/row_metadata.rs
+++ b/src/metadata/row_metadata.rs
@@ -85,13 +85,14 @@ impl RowGroupMetaData {
             })
             .next()
             .unwrap_or(None);
+        let total_compressed_size = Some(self.compressed_size());
         RowGroup {
             columns: self.columns.into_iter().map(|v| v.into_thrift()).collect(),
             total_byte_size: self.total_byte_size,
             num_rows: self.num_rows,
             sorting_columns: None,
-            file_offset: file_offset,
-            total_compressed_size: None,
+            file_offset,
+            total_compressed_size,
             ordinal: None,
         }
     }

--- a/src/schema/io_message/from_message.rs
+++ b/src/schema/io_message/from_message.rs
@@ -198,7 +198,7 @@ impl<'a> Tokenizer<'a> {
     pub fn from_str(string: &'a str) -> Self {
         let vec = string
             .split_whitespace()
-            .flat_map(|t| Self::split_token(t))
+            .flat_map(Self::split_token)
             .collect();
         Tokenizer {
             tokens: vec,

--- a/src/schema/io_thrift/to_thrift.rs
+++ b/src/schema/io_thrift/to_thrift.rs
@@ -32,7 +32,7 @@ fn to_thrift_helper(schema: &ParquetType, elements: &mut Vec<SchemaElement>) {
             let (type_, type_length) = physical_type_to_type(physical_type);
             let converted_type = converted_type
                 .as_ref()
-                .map(|x| primitive_converted_to_converted(x));
+                .map(primitive_converted_to_converted);
             let (converted_type, maybe_decimal) = converted_type
                 .map(|x| (Some(x.0), x.1))
                 .unwrap_or((None, None));
@@ -58,9 +58,7 @@ fn to_thrift_helper(schema: &ParquetType, elements: &mut Vec<SchemaElement>) {
             logical_type,
             converted_type,
         } => {
-            let converted_type = converted_type
-                .as_ref()
-                .map(|x| group_converted_converted_to(x));
+            let converted_type = converted_type.as_ref().map(group_converted_converted_to);
 
             let repetition_type = if basic_info.is_root() {
                 // https://github.com/apache/parquet-format/blob/7f06e838cbd1b7dbd722ff2580b9c2525e37fc46/src/main/thrift/parquet.thrift#L363

--- a/src/write/column_chunk.rs
+++ b/src/write/column_chunk.rs
@@ -51,7 +51,11 @@ where
 
     // write metadata
     let mut protocol = TCompactOutputProtocol::new(writer);
-    bytes_written += column_chunk.meta_data.as_ref().unwrap().write_to_out_protocol(&mut protocol)? as u64;
+    bytes_written += column_chunk
+        .meta_data
+        .as_ref()
+        .unwrap()
+        .write_to_out_protocol(&mut protocol)? as u64;
     protocol.flush()?;
 
     Ok((column_chunk, bytes_written))
@@ -83,7 +87,10 @@ where
 
     // write metadata
     let mut protocol = TCompactOutputStreamProtocol::new(writer);
-    bytes_written += column_chunk.meta_data.as_ref().unwrap()
+    bytes_written += column_chunk
+        .meta_data
+        .as_ref()
+        .unwrap()
         .write_to_out_stream_protocol(&mut protocol)
         .await?;
     protocol.flush().await?;
@@ -126,7 +133,7 @@ fn build_column_chunk(
         .sum();
     let encodings = specs
         .iter()
-        .map(|spec| {
+        .flat_map(|spec| {
             let type_ = spec.header.type_.try_into().unwrap();
             match type_ {
                 PageType::DataPage => vec![
@@ -149,7 +156,6 @@ fn build_column_chunk(
                 _ => todo!(),
             }
         })
-        .flatten()
         .collect::<HashSet<_>>() // unique
         .into_iter() // to vec
         .collect();

--- a/src/write/file.rs
+++ b/src/write/file.rs
@@ -101,6 +101,7 @@ impl<W: Write> FileWriter<W> {
                 "You must call `start` before writing the first row group".to_string(),
             ));
         }
+        let ordinal = self.row_groups.len();
         let (group, size) = write_row_group(
             &mut self.writer,
             self.offset,
@@ -108,6 +109,7 @@ impl<W: Write> FileWriter<W> {
             self.options.compression,
             row_group,
             num_rows,
+            ordinal,
         )?;
         self.offset += size;
         self.row_groups.push(group);

--- a/src/write/statistics.rs
+++ b/src/write/statistics.rs
@@ -11,8 +11,7 @@ pub fn reduce(stats: &[&Option<Arc<dyn Statistics>>]) -> Result<Option<Arc<dyn S
     }
     let stats = stats
         .iter()
-        .map(|x| x.as_ref())
-        .flatten()
+        .filter_map(|x| x.as_ref())
         .map(|x| x.as_ref())
         .collect::<Vec<&dyn Statistics>>();
     if stats.is_empty() {


### PR DESCRIPTION
* afaik `ordinal` is used for id-based row group selection
* `total_compressed_size` to get a rough size of the data
