### PR TITLE
Bump zstd to 0.11.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ snap = { version = "^1.0", optional = true }
 brotli = { version = "^3.3", optional = true }
 flate2 = { version = "^1.0", optional = true }
 lz4 = { version = "1", optional = true }
-zstd = { version = "^0.11", optional = true, default-features = false }
+zstd = { version = "^0.11.1", optional = true, default-features = false }
 
 [features]
 default = ["snappy", "gzip", "lz4", "zstd", "brotli", "stream"]


### PR DESCRIPTION
The released 0.11 `zstd` didn't update the `Cargo.toml'`s `include` field and so didn't include the necessary header shim files for `wasm32-unknown-unknown` in the Cargo package. This is now included in the 0.11.1 release. So this now builds with
```
cargo build --target wasm32-unknown-unknown --no-default-features --features zstd -
-features stream
```
(Note that `--no-default-features` by itself fails with `use of undeclared crate or module `futures``, so `stream` is always required; not sure if that's intentional.)