### PR TITLE
Simplified `PageIterator`

### DIFF
--- a/src/parquet_bridge.rs
+++ b/src/parquet_bridge.rs
@@ -90,7 +90,6 @@ pub enum PageType {
     DataPage,
     DataPageV2,
     DictionaryPage,
-    IndexPage,
 }
 
 impl TryFrom<ParquetPageType> for PageType {
@@ -101,7 +100,6 @@ impl TryFrom<ParquetPageType> for PageType {
             ParquetPageType::DATA_PAGE => PageType::DataPage,
             ParquetPageType::DATA_PAGE_V2 => PageType::DataPageV2,
             ParquetPageType::DICTIONARY_PAGE => PageType::DictionaryPage,
-            ParquetPageType::INDEX_PAGE => PageType::IndexPage,
             _ => return Err(ParquetError::OutOfSpec("Thrift out of range".to_string())),
         })
     }
@@ -113,7 +111,6 @@ impl From<PageType> for ParquetPageType {
             PageType::DataPage => ParquetPageType::DATA_PAGE,
             PageType::DataPageV2 => ParquetPageType::DATA_PAGE_V2,
             PageType::DictionaryPage => ParquetPageType::DICTIONARY_PAGE,
-            PageType::IndexPage => ParquetPageType::INDEX_PAGE,
         }
     }
 }

--- a/src/read/compression.rs
+++ b/src/read/compression.rs
@@ -6,7 +6,7 @@ use crate::error::{ParquetError, Result};
 use crate::page::{CompressedDataPage, DataPage, DataPageHeader};
 use crate::FallibleStreamingIterator;
 
-use super::PageIterator;
+use super::page::PageIterator;
 
 fn decompress_v1(compressed: &[u8], compression: Compression, buffer: &mut [u8]) -> Result<()> {
     compression::decompress(compression, compressed, buffer)

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -1,9 +1,7 @@
 mod compression;
 pub mod levels;
 mod metadata;
-mod page_iterator;
-#[cfg(feature = "stream")]
-mod page_stream;
+mod page;
 #[cfg(feature = "stream")]
 mod stream;
 
@@ -13,9 +11,9 @@ use std::vec::IntoIter;
 
 pub use compression::{decompress, BasicDecompressor, Decompressor};
 pub use metadata::read_metadata;
-pub use page_iterator::{PageFilter, PageReader};
 #[cfg(feature = "stream")]
-pub use page_stream::get_page_stream;
+pub use page::get_page_stream;
+pub use page::{PageFilter, PageReader};
 #[cfg(feature = "stream")]
 pub use stream::read_metadata as read_metadata_async;
 
@@ -24,10 +22,6 @@ use crate::metadata::{ColumnChunkMetaData, RowGroupMetaData};
 use crate::page::CompressedDataPage;
 use crate::schema::types::ParquetType;
 use crate::{error::Result, metadata::FileMetaData};
-
-pub trait PageIterator: Iterator<Item = Result<CompressedDataPage>> {
-    fn swap_buffer(&mut self, buffer: &mut Vec<u8>);
-}
 
 /// Filters row group metadata to only those row groups,
 /// for which the predicate function returns true

--- a/src/read/page/mod.rs
+++ b/src/read/page/mod.rs
@@ -1,0 +1,14 @@
+mod reader;
+#[cfg(feature = "stream")]
+mod stream;
+
+use crate::{error::ParquetError, page::CompressedDataPage};
+
+pub use reader::{PageFilter, PageReader};
+
+pub trait PageIterator: Iterator<Item = Result<CompressedDataPage, ParquetError>> {
+    fn swap_buffer(&mut self, buffer: &mut Vec<u8>);
+}
+
+#[cfg(feature = "stream")]
+pub use stream::get_page_stream;

--- a/src/read/page/reader.rs
+++ b/src/read/page/reader.rs
@@ -160,7 +160,6 @@ fn build_page<R: Read>(
             reader.current_dictionary = Some(dict);
             Ok(None)
         }
-        _ => Ok(None),
     }
 }
 

--- a/src/read/page/stream.rs
+++ b/src/read/page/stream.rs
@@ -9,7 +9,7 @@ use crate::error::Result;
 use crate::metadata::{ColumnChunkMetaData, ColumnDescriptor};
 use crate::page::{CompressedDataPage, ParquetPageHeader};
 
-use super::page_iterator::{finish_page, get_page_header, FinishedPage};
+use super::reader::{finish_page, get_page_header, FinishedPage};
 use super::PageFilter;
 
 /// Returns a stream of compressed data pages
@@ -81,7 +81,6 @@ fn _get_page_stream<'a, R: AsyncRead + AsyncSeek + Unpin + Send>(
                     current_dictionary = Some(dict);
                     continue
                 }
-                _ => continue,
             }
         }
     }

--- a/src/read/page_iterator.rs
+++ b/src/read/page_iterator.rs
@@ -167,7 +167,6 @@ fn build_page<R: Read>(
 pub(super) enum FinishedPage {
     Data(CompressedDataPage),
     Dict(Arc<dyn DictPage>),
-    Index,
 }
 
 pub(super) fn finish_page(
@@ -222,7 +221,6 @@ pub(super) fn finish_page(
                 descriptor.clone(),
             )))
         }
-        PageType::IndexPage => Ok(FinishedPage::Index),
     }
 }
 

--- a/src/write/column_chunk.rs
+++ b/src/write/column_chunk.rs
@@ -153,7 +153,6 @@ fn build_column_chunk(
                         .unwrap()
                         .encoding,
                 ],
-                _ => todo!(),
             }
         })
         .collect::<HashSet<_>>() // unique


### PR DESCRIPTION
* Renamed it to `PageReader`
* Added trait `PageIterator`
* Removed internal state for page index, since page indexes are only present in metadata
