### PR TITLE
Simpler representation of logical types

### DIFF
--- a/src/compression.rs
+++ b/src/compression.rs
@@ -1,3 +1,4 @@
+//! Functionality to compress and decompress data according to the parquet specification
 pub use super::parquet_bridge::Compression;
 
 use crate::error::{Error, Result};

--- a/src/deserialize/fixed_len.rs
+++ b/src/deserialize/fixed_len.rs
@@ -68,7 +68,7 @@ impl<'a> FixedLenBinaryPageState<'a> {
         let size: usize = if let PhysicalType::FixedLenByteArray(size) =
             page.descriptor.primitive_type.physical_type
         {
-            size.try_into()?
+            size
         } else {
             return Err(Error::General(
                 "FixedLenBinaryPageState must be initialized by pages of FixedLenByteArray"

--- a/src/deserialize/hybrid_rle.rs
+++ b/src/deserialize/hybrid_rle.rs
@@ -47,6 +47,11 @@ impl<'a, I: Iterator<Item = hybrid_rle::HybridEncoded<'a>>> HybridBitmapIter<'a,
         self.length - self.consumed
     }
 
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// fetches the next bitmap, optionally limited.
     /// When limited, a run of the hybrid may return an offsetted bitmap
     pub fn limited_next(&mut self, limit: Option<usize>) -> Option<HybridEncoded<'a>> {

--- a/src/deserialize/mod.rs
+++ b/src/deserialize/mod.rs
@@ -8,6 +8,6 @@ mod utils;
 pub use binary::*;
 pub use boolean::*;
 pub use fixed_len::*;
-pub use hybrid_rle::HybridEncoded;
+pub use hybrid_rle::*;
 pub use native::*;
 pub use utils::{DefLevelsDecoder, HybridDecoderBitmapIter};

--- a/src/deserialize/native.rs
+++ b/src/deserialize/native.rs
@@ -3,13 +3,15 @@ use crate::{
     error::Error,
     page::{split_buffer, DataPage, PrimitivePageDict},
     parquet_bridge::{Encoding, Repetition},
-    types::{NativeType, decode},
+    types::{decode, NativeType},
 };
 
 use super::utils;
 
+/// Typedef of an iterator over PLAIN page values
 pub type Casted<'a, T> = std::iter::Map<std::slice::ChunksExact<'a, u8>, fn(&'a [u8]) -> T>;
 
+/// Views the values of the data page as [`Casted`] to [`NativeType`].
 pub fn native_cast<T: NativeType>(page: &DataPage) -> Result<Casted<T>, Error> {
     let (_, _, values) = split_buffer(page);
     if values.len() % std::mem::size_of::<T>() != 0 {
@@ -55,19 +57,26 @@ where
     }
 }
 
-// The deserialization state of a `DataPage` of `Primitive` parquet primitive type
+/// The deserialization state of a `DataPage` of `Primitive` parquet primitive type
 #[derive(Debug)]
 pub enum NativePageState<'a, T>
 where
     T: NativeType,
 {
+    /// A page of optional values
     Optional(utils::DefLevelsDecoder<'a>, Casted<'a, T>),
+    /// A page of required values
     Required(Casted<'a, T>),
+    /// A page of required, dictionary-encoded values
     RequiredDictionary(Dictionary<'a, T>),
+    /// A page of optional, dictionary-encoded values
     OptionalDictionary(utils::DefLevelsDecoder<'a>, Dictionary<'a, T>),
 }
 
 impl<'a, T: NativeType> NativePageState<'a, T> {
+    /// Tries to create [`NativePageState`]
+    /// # Error
+    /// Errors iff the page is not a `NativePageState`
     pub fn try_new(page: &'a DataPage) -> Result<Self, Error> {
         let is_optional =
             page.descriptor.primitive_type.field_info.repetition == Repetition::Optional;

--- a/src/deserialize/utils.rs
+++ b/src/deserialize/utils.rs
@@ -20,9 +20,14 @@ pub(super) fn dict_indices_decoder(page: &DataPage) -> hybrid_rle::HybridRleDeco
 /// Type definition for a [`HybridBitmapIter`]
 pub type HybridDecoderBitmapIter<'a> = HybridBitmapIter<'a, hybrid_rle::Decoder<'a>>;
 
+/// Decoder of definition levels.
 #[derive(Debug)]
 pub enum DefLevelsDecoder<'a> {
+    /// When the maximum definition level is 1, the definition levels are RLE-encoded and
+    /// the bitpacked runs are bitmaps. This variant contains [`HybridDecoderBitmapIter`]
+    /// that decodes the runs, but not the individual values
     Bitmap(HybridDecoderBitmapIter<'a>),
+    /// When the maximum definition level is 1,
     Levels(HybridRleDecoder<'a>, u32),
 }
 

--- a/src/encoding/hybrid_rle/mod.rs
+++ b/src/encoding/hybrid_rle/mod.rs
@@ -8,6 +8,7 @@ pub use encoder::{encode_bool, encode_u32};
 
 use super::bitpacking;
 
+/// The two possible states of an RLE-encoded run.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HybridEncoded<'a> {
     /// A bitpacked slice. The consumer must know its bit-width to unpack it.
@@ -24,7 +25,7 @@ enum State<'a> {
     Rle(std::iter::Take<std::iter::Repeat<u32>>),
 }
 
-// Decoder of Hybrid-RLE encoded values.
+/// [`Iterator`] of [`u32`] from a byte slice of Hybrid-RLE encoded values
 #[derive(Debug, Clone)]
 pub struct HybridRleDecoder<'a> {
     decoder: Decoder<'a>,
@@ -58,6 +59,7 @@ fn read_next<'a, 'b>(decoder: &'b mut Decoder<'a>, remaining: usize) -> State<'a
 }
 
 impl<'a> HybridRleDecoder<'a> {
+    /// Returns a new [`HybridRleDecoder`]
     pub fn new(data: &'a [u8], num_bits: u32, num_values: usize) -> Self {
         let mut decoder = Decoder::new(data, num_bits);
         let state = read_next(&mut decoder, num_values);

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+//! Contains [`Error`]
 use std::sync::Arc;
 
 /// List of features whose non-activation may cause a runtime error.
@@ -5,10 +6,15 @@ use std::sync::Arc;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum Feature {
+    /// Snappy compression and decompression
     Snappy,
+    /// Brotli compression and decompression
     Brotli,
+    /// Gzip compression and decompression
     Gzip,
+    /// Lz4 raw compression and decompression
     Lz4,
+    /// Zstd compression and decompression
     Zstd,
 }
 
@@ -22,7 +28,7 @@ pub enum Error {
     FeatureNotActive(Feature, String),
     /// When the parquet file is known to be out of spec.
     OutOfSpec(String),
-    // An error originating from a consumer or dependency
+    /// An error originating from a consumer or dependency
     External(String, Arc<dyn std::error::Error + Send + Sync>),
 }
 

--- a/src/metadata/column_chunk_metadata.rs
+++ b/src/metadata/column_chunk_metadata.rs
@@ -1,4 +1,3 @@
-use std::convert::TryInto;
 use std::sync::Arc;
 
 use parquet_format_async_temp::{ColumnChunk, ColumnMetaData, Encoding};

--- a/src/metadata/column_descriptor.rs
+++ b/src/metadata/column_descriptor.rs
@@ -1,5 +1,7 @@
 use crate::schema::types::{ParquetType, PrimitiveType};
 
+/// A descriptor of a parquet column. It contains the necessary information to deserialize
+/// a parquet column.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Descriptor {
     /// The [`PrimitiveType`] of this column
@@ -17,10 +19,10 @@ pub struct Descriptor {
 /// re-assemble nested data.
 #[derive(Debug, PartialEq, Clone)]
 pub struct ColumnDescriptor {
-    // The descriptor this columns' leaf.
+    /// The descriptor this columns' leaf.
     pub descriptor: Descriptor,
 
-    // The path of this column. For instance, "a.b.c.d".
+    /// The path of this column. For instance, "a.b.c.d".
     pub path_in_schema: Vec<String>,
 
     /// The [`ParquetType`] this descriptor is a leaf of

--- a/src/metadata/file_metadata.rs
+++ b/src/metadata/file_metadata.rs
@@ -3,7 +3,7 @@ use crate::{error::Error, metadata::get_sort_order};
 use super::{column_order::ColumnOrder, schema_descriptor::SchemaDescriptor, RowGroupMetaData};
 use parquet_format_async_temp::ColumnOrder as TColumnOrder;
 
-pub type KeyValue = parquet_format_async_temp::KeyValue;
+pub use parquet_format_async_temp::KeyValue;
 
 /// Metadata for a Parquet file.
 // This is almost equal to [`parquet_format_async_temp::FileMetaData`] but contains the descriptors,

--- a/src/page/mod.rs
+++ b/src/page/mod.rs
@@ -32,6 +32,7 @@ pub struct CompressedDataPage {
 }
 
 impl CompressedDataPage {
+    /// Returns a new [`CompressedDataPage`].
     pub fn new(
         header: DataPageHeader,
         buffer: Vec<u8>,

--- a/src/page/page_dict/fixed_len_binary.rs
+++ b/src/page/page_dict/fixed_len_binary.rs
@@ -49,11 +49,11 @@ fn read_plain(bytes: &[u8], size: usize, length: usize) -> Vec<u8> {
     bytes[..size * length].to_vec()
 }
 
-pub fn read(buf: &[u8], size: i32, num_values: usize) -> Result<Arc<dyn DictPage>> {
-    let values = read_plain(buf, size as usize, num_values);
+pub fn read(buf: &[u8], size: usize, num_values: usize) -> Result<Arc<dyn DictPage>> {
+    let values = read_plain(buf, size, num_values);
     Ok(Arc::new(FixedLenByteArrayPageDict::new(
         values,
         PhysicalType::FixedLenByteArray(size),
-        size as usize,
+        size,
     )))
 }

--- a/src/parquet_bridge.rs
+++ b/src/parquet_bridge.rs
@@ -480,3 +480,72 @@ impl From<PrimitiveLogicalType> for ParquetLogicalType {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_primitive() -> Result<(), Error> {
+        use PrimitiveLogicalType::*;
+        let a = vec![
+            String,
+            Enum,
+            Decimal(3, 1),
+            Date,
+            Time {
+                unit: TimeUnit::Milliseconds,
+                is_adjusted_to_utc: true,
+            },
+            Timestamp {
+                unit: TimeUnit::Milliseconds,
+                is_adjusted_to_utc: true,
+            },
+            Integer(IntegerType::Int16),
+            Unknown,
+            Json,
+            Bson,
+            Uuid,
+        ];
+        for a in a {
+            let c: ParquetLogicalType = a.into();
+            let e: PrimitiveLogicalType = c.try_into()?;
+            assert_eq!(e, a);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn round_trip_encoding() -> Result<(), Error> {
+        use Encoding::*;
+        let a = vec![
+            Plain,
+            PlainDictionary,
+            Rle,
+            BitPacked,
+            DeltaBinaryPacked,
+            DeltaLengthByteArray,
+            DeltaByteArray,
+            RleDictionary,
+            ByteStreamSplit,
+        ];
+        for a in a {
+            let c: ParquetEncoding = a.into();
+            let e: Encoding = c.try_into()?;
+            assert_eq!(e, a);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn round_compression() -> Result<(), Error> {
+        use Compression::*;
+        let a = vec![Uncompressed, Snappy, Gzip, Lzo, Brotli, Lz4, Zstd, Lz4Raw];
+        for a in a {
+            let c: CompressionCodec = a.into();
+            let e: Compression = c.try_into()?;
+            assert_eq!(e, a);
+        }
+        Ok(())
+    }
+}

--- a/src/parquet_bridge.rs
+++ b/src/parquet_bridge.rs
@@ -11,10 +11,14 @@ use parquet_format_async_temp::Encoding as ParquetEncoding;
 use parquet_format_async_temp::FieldRepetitionType;
 use parquet_format_async_temp::PageType as ParquetPageType;
 
+/// The repetition of a parquet field
 #[derive(Debug, Eq, PartialEq, Hash, Clone, Copy)]
 pub enum Repetition {
+    /// When the field has no null values
     Required,
+    /// When the field may have null values
     Optional,
+    /// When the field may be repeated (list field)
     Repeated,
 }
 

--- a/src/read/compression.rs
+++ b/src/read/compression.rs
@@ -115,7 +115,7 @@ fn decompress_reuse<P: PageIterator>(
     Ok((new_page, was_decompressed))
 }
 
-/// Decompressor that allows re-using the page buffer of [`PageReader`].
+/// Decompressor that allows re-using the page buffer of [`PageIterator`].
 /// # Implementation
 /// The implementation depends on whether a page is compressed or not.
 /// > `PageReader(a)`, `CompressedPage(b)`, `Decompressor(c)`, `DecompressedPage(d)`

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -14,7 +14,7 @@ pub use compression::{decompress, BasicDecompressor, Decompressor};
 pub use metadata::read_metadata;
 #[cfg(feature = "stream")]
 pub use page::get_page_stream;
-pub use page::{IndexedPageReader, PageFilter, PageReader};
+pub use page::{IndexedPageReader, PageFilter, PageIterator, PageReader};
 #[cfg(feature = "stream")]
 pub use stream::read_metadata as read_metadata_async;
 

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -104,6 +104,7 @@ pub enum State<T> {
     Finished(Vec<u8>),
 }
 
+/// A special kind of fallible streaming iterator where `advance` consumes the iterator.
 pub trait MutStreamingIterator: Sized {
     type Item;
     type Error;
@@ -132,6 +133,7 @@ pub struct ColumnIterator<R: Read + Seek> {
 }
 
 impl<R: Read + Seek> ColumnIterator<R> {
+    /// Returns a new [`ColumnIterator`]
     pub fn new(
         reader: R,
         field: ParquetType,
@@ -198,6 +200,7 @@ pub struct ReadColumnIterator {
 }
 
 impl ReadColumnIterator {
+    /// Returns a new [`ReadColumnIterator`]
     pub fn new(
         field: ParquetType,
         chunks: Vec<(Vec<Result<CompressedDataPage>>, ColumnChunkMetaData)>,

--- a/src/read/page/reader.rs
+++ b/src/read/page/reader.rs
@@ -67,6 +67,7 @@ impl<R: Read> PageReader<R> {
         }
     }
 
+    /// Returns the reader and this Readers' interval buffer
     pub fn into_inner(self) -> (R, Vec<u8>) {
         (self.reader, self.buffer)
     }

--- a/src/read/stream.rs
+++ b/src/read/stream.rs
@@ -23,6 +23,7 @@ async fn stream_len(
     Ok(len)
 }
 
+/// Asynchronously reads the files' metadata
 pub async fn read_metadata<R: AsyncRead + AsyncSeek + Send + std::marker::Unpin>(
     reader: &mut R,
 ) -> Result<FileMetaData> {

--- a/src/schema/types/basic_type.rs
+++ b/src/schema/types/basic_type.rs
@@ -3,7 +3,10 @@ use super::super::Repetition;
 /// Common type information.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct FieldInfo {
+    /// The field name
     pub name: String,
+    /// The repetition
     pub repetition: Repetition,
+    /// the optional id, to select fields by id
     pub id: Option<i32>,
 }

--- a/src/schema/types/converted_type.rs
+++ b/src/schema/types/converted_type.rs
@@ -198,3 +198,40 @@ impl From<PrimitiveConvertedType> for (ConvertedType, Option<(i32, i32)>) {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip() -> Result<(), Error> {
+        use PrimitiveConvertedType::*;
+        let a = vec![
+            Utf8,
+            Enum,
+            Decimal(3, 1),
+            Date,
+            TimeMillis,
+            TimeMicros,
+            TimestampMillis,
+            TimestampMicros,
+            Uint8,
+            Uint16,
+            Uint32,
+            Uint64,
+            Int8,
+            Int16,
+            Int32,
+            Int64,
+            Json,
+            Bson,
+            Interval,
+        ];
+        for a in a {
+            let (c, d): (ConvertedType, Option<(i32, i32)>) = a.into();
+            let e: PrimitiveConvertedType = (c, d).try_into()?;
+            assert_eq!(e, a);
+        }
+        Ok(())
+    }
+}

--- a/src/schema/types/converted_type.rs
+++ b/src/schema/types/converted_type.rs
@@ -1,7 +1,7 @@
-use crate::error::{Error, Result};
+use crate::error::Error;
 use parquet_format_async_temp::ConvertedType;
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum PrimitiveConvertedType {
     Utf8,
     /// an enum is converted into a binary field
@@ -19,7 +19,7 @@ pub enum PrimitiveConvertedType {
     /// would have precision 3 (3 total digits) and scale 2 (the decimal point is
     /// 2 digits over).
     // (precision, scale)
-    Decimal(i32, i32),
+    Decimal(usize, usize),
     /// A Date
     ///
     /// Stored as days since Unix epoch, encoded as the INT32 physical type.
@@ -88,7 +88,7 @@ pub enum PrimitiveConvertedType {
     Interval,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum GroupConvertedType {
     /// a map is converted as an optional field containing a repeated key/value pair
     Map,
@@ -99,93 +99,102 @@ pub enum GroupConvertedType {
     List,
 }
 
-pub fn converted_to_primitive_converted(
-    ty: &ConvertedType,
-    maybe_decimal: Option<(i32, i32)>,
-) -> Result<PrimitiveConvertedType> {
-    use PrimitiveConvertedType::*;
-    Ok(match *ty {
-        ConvertedType::UTF8 => Utf8,
-        ConvertedType::ENUM => Enum,
-        ConvertedType::DECIMAL => {
-            if let Some(maybe_decimal) = maybe_decimal {
-                Decimal(maybe_decimal.0, maybe_decimal.1)
-            } else {
-                return Err(general_err!("Decimal requires a precision and scale"));
+impl TryFrom<(ConvertedType, Option<(i32, i32)>)> for PrimitiveConvertedType {
+    type Error = Error;
+
+    fn try_from(
+        (ty, maybe_decimal): (ConvertedType, Option<(i32, i32)>),
+    ) -> Result<Self, Self::Error> {
+        use PrimitiveConvertedType::*;
+        Ok(match ty {
+            ConvertedType::UTF8 => Utf8,
+            ConvertedType::ENUM => Enum,
+            ConvertedType::DECIMAL => {
+                if let Some((precision, scale)) = maybe_decimal {
+                    Decimal(precision.try_into()?, scale.try_into()?)
+                } else {
+                    return Err(general_err!("Decimal requires a precision and scale"));
+                }
             }
-        }
-        ConvertedType::DATE => Date,
-        ConvertedType::TIME_MILLIS => TimeMillis,
-        ConvertedType::TIME_MICROS => TimeMicros,
-        ConvertedType::TIMESTAMP_MILLIS => TimestampMillis,
-        ConvertedType::TIMESTAMP_MICROS => TimestampMicros,
-        ConvertedType::UINT_8 => Uint8,
-        ConvertedType::UINT_16 => Uint16,
-        ConvertedType::UINT_32 => Uint32,
-        ConvertedType::UINT_64 => Uint64,
-        ConvertedType::INT_8 => Int8,
-        ConvertedType::INT_16 => Int16,
-        ConvertedType::INT_32 => Int32,
-        ConvertedType::INT_64 => Int64,
-        ConvertedType::JSON => Json,
-        ConvertedType::BSON => Bson,
-        ConvertedType::INTERVAL => Interval,
-        _ => {
-            return Err(general_err!(
-                "Converted type \"{:?}\" cannot be applied to a primitive type",
-                ty
-            ))
-        }
-    })
-}
-
-pub fn converted_to_group_converted(ty: &ConvertedType) -> Result<GroupConvertedType> {
-    use GroupConvertedType::*;
-    Ok(match *ty {
-        ConvertedType::MAP => Map,
-        ConvertedType::LIST => List,
-        ConvertedType::MAP_KEY_VALUE => MapKeyValue,
-        _ => {
-            return Err(general_err!(
-                "Converted type \"{:?}\" cannot be applied to a primitive type",
-                ty
-            ))
-        }
-    })
-}
-
-pub fn primitive_converted_to_converted(
-    ty: &PrimitiveConvertedType,
-) -> (ConvertedType, Option<(i32, i32)>) {
-    use PrimitiveConvertedType::*;
-    match ty {
-        Utf8 => (ConvertedType::UTF8, None),
-        Enum => (ConvertedType::ENUM, None),
-        Decimal(precision, scale) => (ConvertedType::DECIMAL, Some((*precision, *scale))),
-        Date => (ConvertedType::DATE, None),
-        TimeMillis => (ConvertedType::TIME_MILLIS, None),
-        TimeMicros => (ConvertedType::TIME_MICROS, None),
-        TimestampMillis => (ConvertedType::TIMESTAMP_MILLIS, None),
-        TimestampMicros => (ConvertedType::TIMESTAMP_MICROS, None),
-        Uint8 => (ConvertedType::UINT_8, None),
-        Uint16 => (ConvertedType::UINT_16, None),
-        Uint32 => (ConvertedType::UINT_32, None),
-        Uint64 => (ConvertedType::UINT_64, None),
-        Int8 => (ConvertedType::INT_8, None),
-        Int16 => (ConvertedType::INT_16, None),
-        Int32 => (ConvertedType::INT_32, None),
-        Int64 => (ConvertedType::INT_64, None),
-        Json => (ConvertedType::JSON, None),
-        Bson => (ConvertedType::BSON, None),
-        Interval => (ConvertedType::INTERVAL, None),
+            ConvertedType::DATE => Date,
+            ConvertedType::TIME_MILLIS => TimeMillis,
+            ConvertedType::TIME_MICROS => TimeMicros,
+            ConvertedType::TIMESTAMP_MILLIS => TimestampMillis,
+            ConvertedType::TIMESTAMP_MICROS => TimestampMicros,
+            ConvertedType::UINT_8 => Uint8,
+            ConvertedType::UINT_16 => Uint16,
+            ConvertedType::UINT_32 => Uint32,
+            ConvertedType::UINT_64 => Uint64,
+            ConvertedType::INT_8 => Int8,
+            ConvertedType::INT_16 => Int16,
+            ConvertedType::INT_32 => Int32,
+            ConvertedType::INT_64 => Int64,
+            ConvertedType::JSON => Json,
+            ConvertedType::BSON => Bson,
+            ConvertedType::INTERVAL => Interval,
+            _ => {
+                return Err(general_err!(
+                    "Converted type \"{:?}\" cannot be applied to a primitive type",
+                    ty
+                ))
+            }
+        })
     }
 }
 
-pub fn group_converted_converted_to(ty: &GroupConvertedType) -> ConvertedType {
-    use GroupConvertedType::*;
-    match ty {
-        Map => ConvertedType::MAP,
-        List => ConvertedType::LIST,
-        MapKeyValue => ConvertedType::MAP_KEY_VALUE,
+impl TryFrom<ConvertedType> for GroupConvertedType {
+    type Error = Error;
+
+    fn try_from(type_: ConvertedType) -> Result<Self, Self::Error> {
+        Ok(match type_ {
+            ConvertedType::LIST => GroupConvertedType::List,
+            ConvertedType::MAP => GroupConvertedType::Map,
+            ConvertedType::MAP_KEY_VALUE => GroupConvertedType::MapKeyValue,
+            _ => {
+                return Err(Error::OutOfSpec(
+                    "LogicalType value out of range".to_string(),
+                ))
+            }
+        })
+    }
+}
+
+impl From<GroupConvertedType> for ConvertedType {
+    fn from(type_: GroupConvertedType) -> Self {
+        match type_ {
+            GroupConvertedType::Map => ConvertedType::MAP,
+            GroupConvertedType::List => ConvertedType::LIST,
+            GroupConvertedType::MapKeyValue => ConvertedType::MAP_KEY_VALUE,
+        }
+    }
+}
+
+impl From<PrimitiveConvertedType> for (ConvertedType, Option<(i32, i32)>) {
+    fn from(ty: PrimitiveConvertedType) -> Self {
+        use PrimitiveConvertedType::*;
+        match ty {
+            Utf8 => (ConvertedType::UTF8, None),
+            Enum => (ConvertedType::ENUM, None),
+            Decimal(precision, scale) => (
+                ConvertedType::DECIMAL,
+                Some((precision as i32, scale as i32)),
+            ),
+            Date => (ConvertedType::DATE, None),
+            TimeMillis => (ConvertedType::TIME_MILLIS, None),
+            TimeMicros => (ConvertedType::TIME_MICROS, None),
+            TimestampMillis => (ConvertedType::TIMESTAMP_MILLIS, None),
+            TimestampMicros => (ConvertedType::TIMESTAMP_MICROS, None),
+            Uint8 => (ConvertedType::UINT_8, None),
+            Uint16 => (ConvertedType::UINT_16, None),
+            Uint32 => (ConvertedType::UINT_32, None),
+            Uint64 => (ConvertedType::UINT_64, None),
+            Int8 => (ConvertedType::INT_8, None),
+            Int16 => (ConvertedType::INT_16, None),
+            Int32 => (ConvertedType::INT_32, None),
+            Int64 => (ConvertedType::INT_64, None),
+            Json => (ConvertedType::JSON, None),
+            Bson => (ConvertedType::BSON, None),
+            Interval => (ConvertedType::INTERVAL, None),
+        }
     }
 }

--- a/src/schema/types/mod.rs
+++ b/src/schema/types/mod.rs
@@ -1,8 +1,3 @@
-//pub use parquet_format_async_temp::FieldRepetitionType as Repetition;
-pub use parquet_format_async_temp::{
-    DecimalType, IntType, LogicalType, TimeType, TimeUnit, TimestampType, Type,
-};
-
 mod spec;
 
 mod physical_type;
@@ -16,3 +11,5 @@ pub use converted_type::*;
 
 mod parquet_type;
 pub use parquet_type::*;
+
+pub use crate::parquet_bridge::{GroupLogicalType, IntegerType, PrimitiveLogicalType, TimeUnit};

--- a/src/schema/types/parquet_type.rs
+++ b/src/schema/types/parquet_type.rs
@@ -4,7 +4,8 @@ use std::collections::HashMap;
 
 use super::super::Repetition;
 use super::{
-    spec, FieldInfo, GroupConvertedType, LogicalType, PhysicalType, PrimitiveConvertedType,
+    spec, FieldInfo, GroupConvertedType, GroupLogicalType, PhysicalType, PrimitiveConvertedType,
+    PrimitiveLogicalType,
 };
 
 /// The complete description of a parquet column
@@ -13,7 +14,7 @@ pub struct PrimitiveType {
     /// The fields' generic information
     pub field_info: FieldInfo,
     /// The optional logical type
-    pub logical_type: Option<LogicalType>,
+    pub logical_type: Option<PrimitiveLogicalType>,
     /// The optional converted type
     pub converted_type: Option<PrimitiveConvertedType>,
     /// The physical type
@@ -44,7 +45,7 @@ pub enum ParquetType {
     PrimitiveType(PrimitiveType),
     GroupType {
         field_info: FieldInfo,
-        logical_type: Option<LogicalType>,
+        logical_type: Option<GroupLogicalType>,
         converted_type: Option<GroupConvertedType>,
         fields: Vec<ParquetType>,
     },
@@ -151,7 +152,7 @@ impl ParquetType {
         physical_type: PhysicalType,
         repetition: Repetition,
         converted_type: Option<PrimitiveConvertedType>,
-        logical_type: Option<LogicalType>,
+        logical_type: Option<PrimitiveLogicalType>,
         id: Option<i32>,
     ) -> Result<Self> {
         spec::check_converted_invariants(&physical_type, &converted_type)?;
@@ -181,7 +182,7 @@ impl ParquetType {
         name: String,
         repetition: Repetition,
         converted_type: Option<GroupConvertedType>,
-        logical_type: Option<LogicalType>,
+        logical_type: Option<GroupLogicalType>,
         fields: Vec<ParquetType>,
         id: Option<i32>,
     ) -> Self {

--- a/src/schema/types/parquet_type.rs
+++ b/src/schema/types/parquet_type.rs
@@ -7,15 +7,21 @@ use super::{
     spec, FieldInfo, GroupConvertedType, LogicalType, PhysicalType, PrimitiveConvertedType,
 };
 
+/// The complete description of a parquet column
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct PrimitiveType {
+    /// The fields' generic information
     pub field_info: FieldInfo,
+    /// The optional logical type
     pub logical_type: Option<LogicalType>,
+    /// The optional converted type
     pub converted_type: Option<PrimitiveConvertedType>,
+    /// The physical type
     pub physical_type: PhysicalType,
 }
 
 impl PrimitiveType {
+    /// Helper method to create an optional field with no logical or converted types.
     pub fn from_physical(name: String, physical_type: PhysicalType) -> Self {
         let field_info = FieldInfo {
             name,
@@ -31,10 +37,8 @@ impl PrimitiveType {
     }
 }
 
-/// Representation of a Parquet type.
-/// Used to describe primitive leaf fields and structs, including top-level schema.
-/// Note that the top-level schema type is represented using `GroupType` whose
-/// repetition is `None`.
+/// Representation of a Parquet type describing primitive and nested fields,
+/// including the top-level schema of the parquet file.
 #[derive(Clone, Debug, PartialEq)]
 pub enum ParquetType {
     PrimitiveType(PrimitiveType),
@@ -167,6 +171,8 @@ impl ParquetType {
         }))
     }
 
+    /// Helper method to create a [`ParquetType::PrimitiveType`] optional field
+    /// with no logical or converted types.
     pub fn from_physical(name: String, physical_type: PhysicalType) -> Self {
         ParquetType::PrimitiveType(PrimitiveType::from_physical(name, physical_type))
     }

--- a/src/statistics/fixed_len_binary.rs
+++ b/src/statistics/fixed_len_binary.rs
@@ -33,18 +33,18 @@ impl Statistics for FixedLenStatistics {
 
 pub fn read(
     v: &ParquetStatistics,
-    size: i32,
+    size: usize,
     primitive_type: PrimitiveType,
 ) -> Result<Arc<dyn Statistics>> {
     if let Some(ref v) = v.max_value {
-        if v.len() != size as usize {
+        if v.len() != size {
             return Err(Error::OutOfSpec(
                 "The max_value of statistics MUST be plain encoded".to_string(),
             ));
         }
     };
     if let Some(ref v) = v.min_value {
-        if v.len() != size as usize {
+        if v.len() != size {
             return Err(Error::OutOfSpec(
                 "The min_value of statistics MUST be plain encoded".to_string(),
             ));

--- a/src/write/column_chunk.rs
+++ b/src/write/column_chunk.rs
@@ -1,12 +1,11 @@
 use std::collections::HashSet;
-use std::convert::TryInto;
 use std::io::Write;
 
 use futures::AsyncWrite;
 use parquet_format_async_temp::thrift::protocol::{
     TCompactOutputProtocol, TCompactOutputStreamProtocol, TOutputProtocol, TOutputStreamProtocol,
 };
-use parquet_format_async_temp::{ColumnChunk, ColumnMetaData};
+use parquet_format_async_temp::{ColumnChunk, ColumnMetaData, Type};
 
 use crate::statistics::serialize_statistics;
 use crate::FallibleStreamingIterator;
@@ -16,7 +15,6 @@ use crate::{
     error::{Error, Result},
     metadata::ColumnDescriptor,
     page::{CompressedPage, PageType},
-    schema::types::physical_type_to_type,
 };
 
 use super::page::{write_page, write_page_async, PageWriteSpec};
@@ -163,7 +161,7 @@ fn build_column_chunk(
     let statistics = reduce(&statistics)?;
     let statistics = statistics.map(|x| serialize_statistics(x.as_ref()));
 
-    let type_ = physical_type_to_type(&descriptor.descriptor.primitive_type.physical_type).0;
+    let (type_, _): (Type, Option<i32>) = descriptor.descriptor.primitive_type.physical_type.into();
 
     let metadata = ColumnMetaData {
         type_,

--- a/src/write/compression.rs
+++ b/src/write/compression.rs
@@ -74,6 +74,13 @@ fn compress_dict(
     ))
 }
 
+/// Compresses an [`EncodedPage`] into a [`CompressedPage`] using `compressed_buffer` as the
+/// intermediary buffer.
+///
+/// `compressed_buffer` is taken by value because it becomes owned by [`CompressedPage`]
+///
+/// # Errors
+/// Errors if the compressor fails
 pub fn compress(
     page: EncodedPage,
     compressed_buffer: Vec<u8>,
@@ -99,10 +106,12 @@ pub struct Compressor<I: Iterator<Item = Result<EncodedPage>>> {
 }
 
 impl<I: Iterator<Item = Result<EncodedPage>>> Compressor<I> {
+    /// Creates a new [`Compressor`]
     pub fn new_from_vec(iter: I, compression: Compression, buffer: Vec<u8>) -> Self {
         Self::new(iter, compression, buffer)
     }
 
+    /// Creates a new [`Compressor`]
     pub fn new(iter: I, compression: Compression, buffer: Vec<u8>) -> Self {
         Self {
             iter,

--- a/src/write/dyn_iter.rs
+++ b/src/write/dyn_iter.rs
@@ -1,6 +1,8 @@
 use crate::FallibleStreamingIterator;
 
 /// [`DynIter`] is an implementation of a single-threaded, dynamically-typed iterator.
+///
+/// This implementation is object safe.
 pub struct DynIter<'a, V> {
     iter: Box<dyn Iterator<Item = V> + 'a + Send + Sync>,
 }
@@ -17,6 +19,7 @@ impl<'a, V> Iterator for DynIter<'a, V> {
 }
 
 impl<'a, V> DynIter<'a, V> {
+    /// Returns a new [`DynIter`], boxing the incoming iterator
     pub fn new<I>(iter: I) -> Self
     where
         I: Iterator<Item = V> + 'a + Send + Sync,
@@ -50,6 +53,7 @@ impl<'a, V, E> FallibleStreamingIterator for DynStreamingIterator<'a, V, E> {
 }
 
 impl<'a, V, E> DynStreamingIterator<'a, V, E> {
+    /// Returns a new [`DynStreamingIterator`], boxing the incoming iterator
     pub fn new<I>(iter: I) -> Self
     where
         I: FallibleStreamingIterator<Item = V, Error = E> + 'a + Send + Sync,

--- a/tests/it/read/indexes.rs
+++ b/tests/it/read/indexes.rs
@@ -5,7 +5,9 @@ use parquet2::{
     },
     read::{read_columns_indexes, read_metadata, read_pages_locations},
     schema::{
-        types::{FieldInfo, LogicalType, PhysicalType, PrimitiveConvertedType, PrimitiveType},
+        types::{
+            FieldInfo, PhysicalType, PrimitiveConvertedType, PrimitiveLogicalType, PrimitiveType,
+        },
         Repetition,
     },
 };
@@ -94,7 +96,7 @@ fn test() -> Result<(), Error> {
                     repetition: Repetition::Optional,
                     id: None,
                 },
-                logical_type: Some(LogicalType::STRING(Default::default())),
+                logical_type: Some(PrimitiveLogicalType::String),
                 converted_type: Some(PrimitiveConvertedType::Utf8),
                 physical_type: PhysicalType::ByteArray,
             },


### PR DESCRIPTION
This PR adds an enum layer on top of the thirft-generated structs. The goal is to enforce the specification e.g. non-negative `i32`, when reading files.

This reduces the risk of overflows due to invalid data, as well as risk of missing certain logical types, thereby improving security