### PR TITLE
Fixed design error in filtered pages

### DIFF
--- a/src/deserialize/hybrid_rle.rs
+++ b/src/deserialize/hybrid_rle.rs
@@ -1,6 +1,7 @@
-use crate::encoding::hybrid_rle;
+use crate::encoding::hybrid_rle::{self, BitmapIter};
 
-#[derive(Debug, PartialEq, Eq)]
+/// The decoding state of the hybrid-RLE decoder with a maximum definition level of 1
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HybridEncoded<'a> {
     /// a bitmap
     Bitmap(&'a [u8], usize, usize),
@@ -9,10 +10,15 @@ pub enum HybridEncoded<'a> {
     Repeated(bool, usize),
 }
 
-/// An iterator of [`HybridEncoded`], adapter over [`hybrid_rle::HybridEncoded`],
-/// specialized to be consumed into bitmaps.
+pub trait HybridRleRunsIterator<'a>: Iterator<Item = HybridEncoded<'a>> {
+    /// Number of elements remaining. This may not be the items of the iterator - an item
+    /// of the iterator may contain more than one element.
+    fn number_of_elements(&self) -> usize;
+}
+
+/// An iterator of [`HybridEncoded`], adapter over [`hybrid_rle::HybridEncoded`].
 #[derive(Debug, Clone)]
-pub struct HybridBitmapIter<'a, I: Iterator<Item = hybrid_rle::HybridEncoded<'a>>> {
+pub struct HybridRleIter<'a, I: Iterator<Item = hybrid_rle::HybridEncoded<'a>>> {
     iter: I,
     current: Option<hybrid_rle::HybridEncoded<'a>>,
     // invariants:
@@ -27,8 +33,8 @@ pub struct HybridBitmapIter<'a, I: Iterator<Item = hybrid_rle::HybridEncoded<'a>
     length: usize,
 }
 
-impl<'a, I: Iterator<Item = hybrid_rle::HybridEncoded<'a>>> HybridBitmapIter<'a, I> {
-    /// Returns a new [`HybridBitmapIter`]
+impl<'a, I: Iterator<Item = hybrid_rle::HybridEncoded<'a>>> HybridRleIter<'a, I> {
+    /// Returns a new [`HybridRleIter`]
     #[inline]
     pub fn new(mut iter: I, length: usize) -> Self {
         let current = iter.next();
@@ -41,7 +47,7 @@ impl<'a, I: Iterator<Item = hybrid_rle::HybridEncoded<'a>>> HybridBitmapIter<'a,
         }
     }
 
-    /// the number of elements in the iterator
+    /// the number of elements in the iterator. Note that this _is not_ the number of runs.
     #[inline]
     pub fn len(&self) -> usize {
         self.length - self.consumed
@@ -53,7 +59,7 @@ impl<'a, I: Iterator<Item = hybrid_rle::HybridEncoded<'a>>> HybridBitmapIter<'a,
     }
 
     /// fetches the next bitmap, optionally limited.
-    /// When limited, a run of the hybrid may return an offsetted bitmap
+    /// When limited, a run may return an offsetted bitmap
     pub fn limited_next(&mut self, limit: Option<usize>) -> Option<HybridEncoded<'a>> {
         if self.consumed == self.length {
             return None;
@@ -118,10 +124,94 @@ impl<'a, I: Iterator<Item = hybrid_rle::HybridEncoded<'a>>> HybridBitmapIter<'a,
     }
 }
 
-impl<'a, I: Iterator<Item = hybrid_rle::HybridEncoded<'a>>> Iterator for HybridBitmapIter<'a, I> {
+impl<'a, I: Iterator<Item = hybrid_rle::HybridEncoded<'a>>> HybridRleRunsIterator<'a>
+    for HybridRleIter<'a, I>
+{
+    fn number_of_elements(&self) -> usize {
+        self.len()
+    }
+}
+
+impl<'a, I: Iterator<Item = hybrid_rle::HybridEncoded<'a>>> Iterator for HybridRleIter<'a, I> {
     type Item = HybridEncoded<'a>;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.limited_next(None)
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.iter.size_hint()
+    }
 }
+
+/// Type definition for a [`HybridRleIter`] using [`hybrid_rle::Decoder`].
+pub type HybridDecoderBitmapIter<'a> = HybridRleIter<'a, hybrid_rle::Decoder<'a>>;
+
+#[derive(Debug)]
+enum HybridBooleanState<'a> {
+    /// a bitmap
+    Bitmap(BitmapIter<'a>),
+    /// A repeated item. The first attribute corresponds to whether the value is set
+    /// the second attribute corresponds to the number of repetitions.
+    Repeated(bool, usize),
+}
+
+/// An iterator adapter that maps an iterator of [`HybridEncoded`] into an iterator
+/// over [`bool`].
+#[derive(Debug)]
+pub struct HybridRleBooleanIter<'a, I: Iterator<Item = HybridEncoded<'a>>> {
+    iter: I,
+    current_run: Option<HybridBooleanState<'a>>,
+}
+
+impl<'a, I: Iterator<Item = HybridEncoded<'a>>> HybridRleBooleanIter<'a, I> {
+    pub fn new(iter: I) -> Self {
+        Self {
+            iter,
+            current_run: None,
+        }
+    }
+}
+
+impl<'a, I: HybridRleRunsIterator<'a>> Iterator for HybridRleBooleanIter<'a, I> {
+    type Item = bool;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(run) = &mut self.current_run {
+            match run {
+                HybridBooleanState::Bitmap(bitmap) => bitmap.next(),
+                HybridBooleanState::Repeated(value, remaining) => {
+                    if *remaining == 0 {
+                        None
+                    } else {
+                        *remaining -= 1;
+                        Some(*value)
+                    }
+                }
+            }
+        } else if let Some(run) = self.iter.next() {
+            self.current_run = Some(match run {
+                HybridEncoded::Bitmap(bitmap, offset, length) => {
+                    HybridBooleanState::Bitmap(BitmapIter::new(bitmap, offset, length))
+                }
+                HybridEncoded::Repeated(value, length) => {
+                    HybridBooleanState::Repeated(value, length)
+                }
+            });
+            self.next()
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let exact = self.iter.number_of_elements();
+        (exact, Some(exact))
+    }
+}
+
+/// Type definition for a [`HybridRleBooleanIter`] using [`hybrid_rle::Decoder`].
+pub type HybridRleDecoderIter<'a> = HybridRleBooleanIter<'a, HybridDecoderBitmapIter<'a>>;

--- a/src/deserialize/mod.rs
+++ b/src/deserialize/mod.rs
@@ -10,4 +10,4 @@ pub use boolean::*;
 pub use fixed_len::*;
 pub use hybrid_rle::*;
 pub use native::*;
-pub use utils::{DefLevelsDecoder, HybridDecoderBitmapIter};
+pub use utils::{DefLevelsDecoder, OptionalValues, SliceFilteredIter};

--- a/src/deserialize/utils.rs
+++ b/src/deserialize/utils.rs
@@ -1,10 +1,13 @@
+use std::collections::VecDeque;
+
 use crate::{
     encoding::hybrid_rle::{self, HybridRleDecoder},
+    indexes::Interval,
     page::{split_buffer, DataPage},
     read::levels::get_bit_width,
 };
 
-use super::hybrid_rle::HybridBitmapIter;
+use super::hybrid_rle::{HybridDecoderBitmapIter, HybridRleIter};
 
 pub(super) fn dict_indices_decoder(page: &DataPage) -> hybrid_rle::HybridRleDecoder {
     let (_, _, indices_buffer) = split_buffer(page);
@@ -17,9 +20,6 @@ pub(super) fn dict_indices_decoder(page: &DataPage) -> hybrid_rle::HybridRleDeco
     hybrid_rle::HybridRleDecoder::new(indices_buffer, bit_width as u32, page.num_values())
 }
 
-/// Type definition for a [`HybridBitmapIter`]
-pub type HybridDecoderBitmapIter<'a> = HybridBitmapIter<'a, hybrid_rle::Decoder<'a>>;
-
 /// Decoder of definition levels.
 #[derive(Debug)]
 pub enum DefLevelsDecoder<'a> {
@@ -27,7 +27,7 @@ pub enum DefLevelsDecoder<'a> {
     /// the bitpacked runs are bitmaps. This variant contains [`HybridDecoderBitmapIter`]
     /// that decodes the runs, but not the individual values
     Bitmap(HybridDecoderBitmapIter<'a>),
-    /// When the maximum definition level is 1,
+    /// When the maximum definition level is larger than 1
     Levels(HybridRleDecoder<'a>, u32),
 }
 
@@ -38,12 +38,118 @@ impl<'a> DefLevelsDecoder<'a> {
         let max_def_level = page.descriptor.max_def_level;
         if max_def_level == 1 {
             let iter = hybrid_rle::Decoder::new(def_levels, 1);
-            let iter = HybridBitmapIter::new(iter, page.num_values());
+            let iter = HybridRleIter::new(iter, page.num_values());
             Self::Bitmap(iter)
         } else {
             let iter =
                 HybridRleDecoder::new(def_levels, get_bit_width(max_def_level), page.num_values());
             Self::Levels(iter, max_def_level as u32)
         }
+    }
+}
+
+/// Iterator adapter to convert an iterator of non-null values and an iterator over validity
+/// into an iterator of optional values.
+#[derive(Debug, Clone)]
+pub struct OptionalValues<T, V: Iterator<Item = bool>, I: Iterator<Item = T>> {
+    validity: V,
+    values: I,
+}
+
+impl<T, V: Iterator<Item = bool>, I: Iterator<Item = T>> OptionalValues<T, V, I> {
+    pub fn new(validity: V, values: I) -> Self {
+        Self { validity, values }
+    }
+}
+
+impl<T, V: Iterator<Item = bool>, I: Iterator<Item = T>> Iterator for OptionalValues<T, V, I> {
+    type Item = Option<T>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        self.validity
+            .next()
+            .map(|x| if x { self.values.next() } else { None })
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.validity.size_hint()
+    }
+}
+
+/// An iterator adapter that converts an iterator over items into an iterator over slices of
+/// those N items.
+///
+/// This iterator is best used with iterators that implement `nth` since skipping items
+/// allows this iterator to skip sequences of items without having to call each of them.
+#[derive(Debug, Clone)]
+pub struct SliceFilteredIter<I> {
+    iter: I,
+    selected_rows: VecDeque<Interval>,
+    current_remaining: usize,
+    current: usize, // position in the slice
+}
+
+impl<I> SliceFilteredIter<I> {
+    /// Return a new [`SliceFilteredIter`]
+    pub fn new(iter: I, selected_rows: VecDeque<Interval>) -> Self {
+        Self {
+            iter,
+            selected_rows,
+            current_remaining: 0,
+            current: 0,
+        }
+    }
+}
+
+impl<T, I: Iterator<Item = T>> Iterator for SliceFilteredIter<I> {
+    type Item = T;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.current_remaining == 0 {
+            if let Some(interval) = self.selected_rows.pop_front() {
+                // skip the hole between the previous start end this start
+                // (start + length) - start
+                let item = self.iter.nth(interval.start - self.current);
+                self.current = interval.start + interval.length;
+                self.current_remaining = interval.length - 1;
+                item
+            } else {
+                None
+            }
+        } else {
+            self.current_remaining -= 1;
+            self.iter.next()
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::collections::VecDeque;
+
+    use super::*;
+
+    #[test]
+    fn basic() {
+        let iter = 0..=100;
+
+        let intervals = vec![
+            Interval::new(0, 2),
+            Interval::new(20, 11),
+            Interval::new(31, 1),
+        ];
+
+        let a: VecDeque<Interval> = intervals.clone().into_iter().collect();
+        let a = SliceFilteredIter::new(iter, a);
+
+        let expected: Vec<usize> = intervals
+            .into_iter()
+            .flat_map(|interval| interval.start..(interval.start + interval.length))
+            .collect();
+
+        assert_eq!(expected, a.collect::<Vec<_>>());
     }
 }

--- a/src/indexes/mod.rs
+++ b/src/indexes/mod.rs
@@ -76,16 +76,17 @@ mod tests {
         assert_eq!(
             pages,
             vec![
-                FilteredPage::Skip {
+                FilteredPage {
                     start: 100,
                     length: 10,
+                    selected_rows: vec![],
                     num_rows: 5
                 },
-                FilteredPage::Select {
+                FilteredPage {
                     start: 110,
                     length: 20,
-                    rows_offset: 0,
-                    rows_length: 5
+                    selected_rows: vec![Interval::new(0, 5)],
+                    num_rows: 5
                 }
             ]
         );
@@ -114,15 +115,16 @@ mod tests {
         assert_eq!(
             pages,
             vec![
-                FilteredPage::Select {
+                FilteredPage {
                     start: 100,
                     length: 20,
-                    rows_offset: 5,
-                    rows_length: 5
+                    selected_rows: vec![Interval::new(5, 5)],
+                    num_rows: 10,
                 },
-                FilteredPage::Skip {
+                FilteredPage {
                     start: 120,
                     length: 20,
+                    selected_rows: vec![],
                     num_rows: 90
                 },
             ]
@@ -158,21 +160,22 @@ mod tests {
         assert_eq!(
             pages,
             vec![
-                FilteredPage::Select {
+                FilteredPage {
                     start: 100,
                     length: 20,
-                    rows_offset: 5,
-                    rows_length: 5
+                    selected_rows: vec![Interval::new(5, 5)],
+                    num_rows: 10,
                 },
-                FilteredPage::Select {
+                FilteredPage {
                     start: 120,
                     length: 20,
-                    rows_offset: 0,
-                    rows_length: 1
+                    selected_rows: vec![Interval::new(0, 1)],
+                    num_rows: 90,
                 },
-                FilteredPage::Skip {
+                FilteredPage {
                     start: 140,
                     length: 20,
+                    selected_rows: vec![],
                     num_rows: 100
                 },
             ]
@@ -208,20 +211,22 @@ mod tests {
         assert_eq!(
             pages,
             vec![
-                FilteredPage::Select {
+                FilteredPage {
                     start: 100,
                     length: 20,
-                    rows_offset: 0,
-                    rows_length: 1
+                    selected_rows: vec![Interval::new(0, 1)],
+                    num_rows: 10,
                 },
-                FilteredPage::Skip {
+                FilteredPage {
                     start: 120,
                     length: 20,
+                    selected_rows: vec![],
                     num_rows: 90
                 },
-                FilteredPage::Skip {
+                FilteredPage {
                     start: 140,
                     length: 20,
+                    selected_rows: vec![],
                     num_rows: 100
                 },
             ]

--- a/src/read/compression.rs
+++ b/src/read/compression.rs
@@ -85,12 +85,12 @@ pub fn decompress(
     buffer: &mut Vec<u8>,
 ) -> Result<DataPage> {
     decompress_buffer(&mut compressed_page, buffer)?;
-    Ok(DataPage::new(
+    Ok(DataPage::new_read(
         compressed_page.header,
         std::mem::take(buffer),
         compressed_page.dictionary_page,
         compressed_page.descriptor,
-        compressed_page.rows,
+        compressed_page.selected_rows,
     ))
 }
 
@@ -101,12 +101,12 @@ fn decompress_reuse<P: PageIterator>(
 ) -> Result<(DataPage, bool)> {
     let was_decompressed = decompress_buffer(&mut compressed_page, buffer)?;
 
-    let new_page = DataPage::new(
+    let new_page = DataPage::new_read(
         compressed_page.header,
         std::mem::take(buffer),
         compressed_page.dictionary_page,
         compressed_page.descriptor,
-        compressed_page.rows,
+        compressed_page.selected_rows,
     );
 
     if was_decompressed {

--- a/src/write/compression.rs
+++ b/src/write/compression.rs
@@ -18,7 +18,7 @@ fn compress_data(
         header,
         dictionary_page,
         descriptor,
-        rows,
+        selected_rows,
     } = page;
     let uncompressed_page_size = buffer.len();
     if compression != Compression::Uncompressed {
@@ -41,14 +41,14 @@ fn compress_data(
     } else {
         std::mem::swap(&mut buffer, &mut compressed_buffer);
     };
-    Ok(CompressedDataPage::new(
+    Ok(CompressedDataPage::new_read(
         header,
         compressed_buffer,
         compression,
         uncompressed_page_size,
         dictionary_page,
         descriptor,
-        rows,
+        selected_rows,
     ))
 }
 

--- a/src/write/page.rs
+++ b/src/write/page.rs
@@ -53,7 +53,7 @@ pub fn write_page<W: Write>(
     compressed_page: &CompressedPage,
 ) -> Result<PageWriteSpec> {
     let num_values = compressed_page.num_values();
-    let rows = compressed_page.rows();
+    let selected_rows = compressed_page.selected_rows();
 
     let header = match &compressed_page {
         CompressedPage::Data(compressed_page) => assemble_data_page_header(compressed_page),
@@ -85,7 +85,7 @@ pub fn write_page<W: Write>(
         offset,
         bytes_written,
         statistics,
-        num_rows: rows.map(|x| x.1),
+        num_rows: selected_rows.map(|x| x.last().unwrap().length),
         num_values,
     })
 }
@@ -96,7 +96,7 @@ pub async fn write_page_async<W: AsyncWrite + Unpin + Send>(
     compressed_page: &CompressedPage,
 ) -> Result<PageWriteSpec> {
     let num_values = compressed_page.num_values();
-    let rows = compressed_page.rows();
+    let selected_rows = compressed_page.selected_rows();
 
     let header = match &compressed_page {
         CompressedPage::Data(compressed_page) => assemble_data_page_header(compressed_page),
@@ -128,7 +128,7 @@ pub async fn write_page_async<W: AsyncWrite + Unpin + Send>(
         offset,
         bytes_written,
         statistics,
-        num_rows: rows.map(|x| x.1),
+        num_rows: selected_rows.map(|x| x.last().unwrap().length),
         num_values,
     })
 }

--- a/tests/it/read/primitive.rs
+++ b/tests/it/read/primitive.rs
@@ -1,23 +1,107 @@
-use parquet2::{deserialize::NativePageState, error::Error, page::DataPage, types::NativeType};
+use parquet2::{
+    deserialize::{
+        native_cast, Casted, HybridRleDecoderIter, HybridRleIter, NativePageState, OptionalValues,
+        SliceFilteredIter,
+    },
+    encoding::{hybrid_rle::Decoder, Encoding},
+    error::Error,
+    page::{split_buffer, DataPage},
+    schema::Repetition,
+    types::NativeType,
+};
 
 use super::utils::deserialize_optional;
 
+/// The deserialization state of a `DataPage` of `Primitive` parquet primitive type
+#[derive(Debug)]
+pub enum FilteredPageState<'a, T>
+where
+    T: NativeType,
+{
+    /// A page of optional values
+    Optional(SliceFilteredIter<OptionalValues<T, HybridRleDecoderIter<'a>, Casted<'a, T>>>),
+    /// A page of required values
+    Required(SliceFilteredIter<Casted<'a, T>>),
+}
+
+/// The deserialization state of a `DataPage` of `Primitive` parquet primitive type
+#[derive(Debug)]
+pub enum PageState<'a, T>
+where
+    T: NativeType,
+{
+    Nominal(NativePageState<'a, T>),
+    Filtered(FilteredPageState<'a, T>),
+}
+
+impl<'a, T: NativeType> PageState<'a, T> {
+    /// Tries to create [`NativePageState`]
+    /// # Error
+    /// Errors iff the page is not a `NativePageState`
+    pub fn try_new(page: &'a DataPage) -> Result<Self, Error> {
+        if let Some(selected_rows) = page.selected_rows() {
+            let is_optional =
+                page.descriptor.primitive_type.field_info.repetition == Repetition::Optional;
+
+            match (page.encoding(), page.dictionary_page(), is_optional) {
+                (Encoding::Plain, _, true) => {
+                    let (_, def_levels, _) = split_buffer(page);
+
+                    let validity = HybridRleDecoderIter::new(HybridRleIter::new(
+                        Decoder::new(def_levels, 1),
+                        page.num_values(),
+                    ));
+                    let values = native_cast(page)?;
+
+                    // validity and values interleaved.
+                    let values = OptionalValues::new(validity, values);
+
+                    let values =
+                        SliceFilteredIter::new(values, selected_rows.iter().copied().collect());
+
+                    Ok(Self::Filtered(FilteredPageState::Optional(values)))
+                }
+                (Encoding::Plain, _, false) => {
+                    let values = SliceFilteredIter::new(
+                        native_cast(page)?,
+                        selected_rows.iter().copied().collect(),
+                    );
+                    Ok(Self::Filtered(FilteredPageState::Required(values)))
+                }
+                _ => Err(Error::General(format!(
+                    "Viewing page for encoding {:?} for native type {} not supported",
+                    page.encoding(),
+                    std::any::type_name::<T>()
+                ))),
+            }
+        } else {
+            NativePageState::try_new(page).map(Self::Nominal)
+        }
+    }
+}
+
 pub fn page_to_vec<T: NativeType>(page: &DataPage) -> Result<Vec<Option<T>>, Error> {
     assert_eq!(page.descriptor.max_rep_level, 0);
-    let state = NativePageState::<T>::try_new(page)?;
+    let state = PageState::<T>::try_new(page)?;
 
     match state {
-        NativePageState::Optional(validity, values) => deserialize_optional(validity, values),
-        NativePageState::Required(values) => Ok(values.map(Some).collect()),
-        NativePageState::RequiredDictionary(dict) => Ok(dict
-            .indexes
-            .map(|x| x as usize)
-            .map(|x| dict.values[x])
-            .map(Some)
-            .collect()),
-        NativePageState::OptionalDictionary(validity, dict) => {
-            let values = dict.indexes.map(|x| x as usize).map(|x| dict.values[x]);
-            deserialize_optional(validity, values)
-        }
+        PageState::Nominal(state) => match state {
+            NativePageState::Optional(validity, values) => deserialize_optional(validity, values),
+            NativePageState::Required(values) => Ok(values.map(Some).collect()),
+            NativePageState::RequiredDictionary(dict) => Ok(dict
+                .indexes
+                .map(|x| x as usize)
+                .map(|x| dict.values[x])
+                .map(Some)
+                .collect()),
+            NativePageState::OptionalDictionary(validity, dict) => {
+                let values = dict.indexes.map(|x| x as usize).map(|x| dict.values[x]);
+                deserialize_optional(validity, values)
+            }
+        },
+        PageState::Filtered(state) => match state {
+            FilteredPageState::Optional(values) => Ok(values.collect()),
+            FilteredPageState::Required(values) => Ok(values.map(Some).collect()),
+        },
     }
 }

--- a/tests/it/write/binary.rs
+++ b/tests/it/write/binary.rs
@@ -84,6 +84,6 @@ pub fn array_to_page_v1(
         buffer,
         None,
         descriptor.clone(),
-        Some((0, array.len())),
+        Some(array.len()),
     )))
 }

--- a/tests/it/write/indexes.rs
+++ b/tests/it/write/indexes.rs
@@ -1,0 +1,139 @@
+use std::io::Cursor;
+
+use parquet2::compression::Compression;
+use parquet2::error::Result;
+use parquet2::indexes::{
+    select_pages, BoundaryOrder, Index, Interval, NativeIndex, PageIndex, PageLocation,
+};
+use parquet2::metadata::SchemaDescriptor;
+use parquet2::read::{
+    read_columns_indexes, read_metadata, read_pages_locations, BasicDecompressor, IndexedPageReader,
+};
+use parquet2::schema::types::{ParquetType, PhysicalType, PrimitiveType};
+use parquet2::write::WriteOptions;
+use parquet2::write::{Compressor, DynIter, DynStreamingIterator, FileWriter, Version};
+use parquet2::FallibleStreamingIterator;
+
+use crate::read::page_to_array;
+use crate::Array;
+
+use super::primitive::array_to_page_v1;
+
+fn write_file() -> Result<Vec<u8>> {
+    let page1 = vec![Some(0), Some(1), None, Some(3), Some(4), Some(5), Some(6)];
+    let page2 = vec![Some(10), Some(11)];
+
+    let options = WriteOptions {
+        write_statistics: true,
+        compression: Compression::Uncompressed,
+        version: Version::V1,
+    };
+
+    let schema = SchemaDescriptor::new(
+        "schema".to_string(),
+        vec![ParquetType::from_physical(
+            "col1".to_string(),
+            PhysicalType::Int32,
+        )],
+    );
+
+    let pages = vec![
+        array_to_page_v1::<i32>(&page1, &options, &schema.columns()[0].descriptor),
+        array_to_page_v1::<i32>(&page2, &options, &schema.columns()[0].descriptor),
+    ];
+
+    let pages = DynStreamingIterator::new(Compressor::new(
+        DynIter::new(pages.into_iter()),
+        options.compression,
+        vec![],
+    ));
+    let columns = std::iter::once(Ok(pages));
+
+    let writer = Cursor::new(vec![]);
+    let mut writer = FileWriter::new(writer, schema, options, None);
+
+    writer.start()?;
+    writer.write(DynIter::new(columns))?;
+    let writer = writer.end(None)?.1;
+
+    Ok(writer.into_inner())
+}
+
+#[test]
+fn read_indexed_page() -> Result<()> {
+    let data = write_file()?;
+    let mut reader = Cursor::new(data);
+
+    let metadata = read_metadata(&mut reader)?;
+
+    let column = 0;
+    let columns = &metadata.row_groups[0].columns();
+
+    // selected the rows
+    let intervals = &[Interval::new(2, 2)];
+
+    let pages = read_pages_locations(&mut reader, columns)?;
+
+    let pages = select_pages(intervals, &pages[column], metadata.row_groups[0].num_rows())?;
+
+    let pages = IndexedPageReader::new(reader, &columns[column], pages, vec![], vec![]);
+
+    let mut pages = BasicDecompressor::new(pages, vec![]);
+
+    let mut arrays = vec![];
+    while let Some(page) = pages.next()? {
+        arrays.push(page_to_array(page)?)
+    }
+
+    // the second item and length 2
+    assert_eq!(arrays, vec![Array::Int32(vec![None, Some(3)])]);
+
+    Ok(())
+}
+
+#[test]
+fn read_indexes_and_locations() -> Result<()> {
+    let data = write_file()?;
+    let mut reader = Cursor::new(data);
+
+    let metadata = read_metadata(&mut reader)?;
+
+    let columns = &metadata.row_groups[0].columns();
+
+    let expected_page_locations = vec![vec![
+        PageLocation {
+            offset: 4,
+            compressed_page_size: 63,
+            first_row_index: 0,
+        },
+        PageLocation {
+            offset: 67,
+            compressed_page_size: 47,
+            first_row_index: 7,
+        },
+    ]];
+    let expected_index = vec![Box::new(NativeIndex::<i32> {
+        primitive_type: PrimitiveType::from_physical("col1".to_string(), PhysicalType::Int32),
+        indexes: vec![
+            PageIndex {
+                min: Some(0),
+                max: Some(6),
+                null_count: Some(1),
+            },
+            PageIndex {
+                min: Some(10),
+                max: Some(11),
+                null_count: Some(0),
+            },
+        ],
+        boundary_order: BoundaryOrder::Unordered,
+    }) as Box<dyn Index>];
+
+    let indexes = read_columns_indexes(&mut reader, columns)?;
+    assert_eq!(&indexes, &expected_index);
+
+    let pages = read_pages_locations(&mut reader, columns)?;
+    assert_eq!(pages, expected_page_locations);
+
+    Ok(())
+}

--- a/tests/it/write/primitive.rs
+++ b/tests/it/write/primitive.rs
@@ -75,6 +75,6 @@ pub fn array_to_page_v1<T: NativeType>(
         buffer,
         None,
         descriptor.clone(),
-        Some((0, array.len())),
+        Some(array.len()),
     )))
 }


### PR DESCRIPTION
This PR fixes a design mistake in how filtered pages should be represented. 

The examples in #102 assumed that a page would only overlap with a single row interval. However, it is possible for multiple row intervals to overlap a single page. The current API in main does not cater for this.

This PR fixes this, therefore closing #102.

Tests demonstrate how a column with pages containing

```rust
let page1 = vec![Some(0), Some(1), None, Some(3), Some(4), Some(5), Some(6)];
let page2 = vec![Some(10), Some(11)];
```

and the selection `let intervals = &[Interval::new(2, 2)];` (start, length) yields `vec![None, Some(3)])]`.

In this model, we do not decompress nor deserialize page2, and we do not deserialize the remaining items from page1.

Closes #102