### PR TITLE
Fix Lz4Raw compression error (if input is tiny) 

### DIFF
--- a/src/compression.rs
+++ b/src/compression.rs
@@ -65,8 +65,8 @@ pub fn compress(
         #[cfg(feature = "lz4")]
         Compression::Lz4Raw => {
             let output_buf_len = output_buf.len();
-            let required_len = input_buf.len();
-            output_buf.resize(output_buf_len + required_len, 0);
+            let required_len = lz4::block::compress_bound(input_buf.len())?;
+            output_buf.resize(required_len, 0);
             let size = lz4::block::compress_to_buffer(
                 input_buf,
                 None,

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -77,6 +77,11 @@ pub fn alltypes_plain(column: &str) -> Array {
             let expected = expected.into_iter().map(Some).collect::<Vec<_>>();
             Array::Int32(expected)
         }
+        "id-short-array" => {
+            let expected = vec![4];
+            let expected = expected.into_iter().map(Some).collect::<Vec<_>>();
+            Array::Int32(expected)
+        }
         "bool_col" => {
             let expected = vec![true, false, true, false, true, false, true, false];
             let expected = expected.into_iter().map(Some).collect::<Vec<_>>();
@@ -155,6 +160,13 @@ pub fn alltypes_statistics(column: &str) -> Arc<dyn Statistics> {
             distinct_count: None,
             min_value: Some(0),
             max_value: Some(7),
+        }),
+        "id-short-array" => Arc::new(PrimitiveStatistics::<i32> {
+            primitive_type: PrimitiveType::from_physical("col".to_string(), PhysicalType::Int32),
+            null_count: Some(0),
+            distinct_count: None,
+            min_value: Some(4),
+            max_value: Some(4),
         }),
         "bool_col" => Arc::new(BooleanStatistics {
             null_count: Some(0),

--- a/tests/it/write/mod.rs
+++ b/tests/it/write/mod.rs
@@ -123,6 +123,11 @@ fn int32_lz4() -> Result<()> {
 }
 
 #[test]
+fn int32_lz4_short_i32_array() -> Result<()> {
+    test_column("id-short-array", Compression::Lz4Raw)
+}
+
+#[test]
 fn int32_brotli() -> Result<()> {
     test_column("id", Compression::Brotli)
 }


### PR DESCRIPTION
Issue 
- #117

By using `lz4::block::compress_bound` to determine the size of output buffer