### PR TITLE
Added specialized deserialization of one-level filtered pages

### DIFF
--- a/src/deserialize/filtered_rle.rs
+++ b/src/deserialize/filtered_rle.rs
@@ -1,0 +1,266 @@
+use std::collections::VecDeque;
+
+use crate::{encoding::hybrid_rle::BitmapIter, indexes::Interval};
+
+use super::{HybridDecoderBitmapIter, HybridEncoded};
+
+/// Type definition of a [`FilteredHybridBitmapIter`] of [`HybridDecoderBitmapIter`].
+pub type FilteredHybridRleDecoderIter<'a> =
+    FilteredHybridBitmapIter<'a, HybridDecoderBitmapIter<'a>>;
+
+/// The decoding state of the hybrid-RLE decoder with a maximum definition level of 1
+/// that can supports skipped runs
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FilteredHybridEncoded<'a> {
+    /// a bitmap (values, offset, length, skipped_set)
+    Bitmap {
+        values: &'a [u8],
+        offset: usize,
+        length: usize,
+    },
+    Repeated {
+        is_set: bool,
+        length: usize,
+    },
+    /// When the run was skipped - contains the number of set values on the skipped run
+    Skipped(usize),
+}
+
+fn is_set_count(values: &[u8], offset: usize, length: usize) -> usize {
+    BitmapIter::new(values, offset, length)
+        .filter(|x| *x)
+        .count()
+}
+
+impl<'a> FilteredHybridEncoded<'a> {
+    /// Returns the length of the run in number of items
+    #[inline]
+    pub fn len(&self) -> usize {
+        match self {
+            FilteredHybridEncoded::Bitmap { length, .. } => *length,
+            FilteredHybridEncoded::Repeated { length, .. } => *length,
+            FilteredHybridEncoded::Skipped(_) => 0,
+        }
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// An [`Iterator`] adapter over [`HybridEncoded`] that yields [`FilteredHybridEncoded`].
+///
+/// This iterator adapter is used in combination with
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FilteredHybridBitmapIter<'a, I: Iterator<Item = HybridEncoded<'a>>> {
+    iter: I,
+    current: Option<(HybridEncoded<'a>, usize)>,
+    // a run may end in the middle of an interval, in which case we must
+    // split the interval in parts. This tracks the current interval being computed
+    current_interval: Option<Interval>,
+    selected_rows: VecDeque<Interval>,
+    current_items_in_runs: usize,
+
+    total_items: usize,
+}
+
+impl<'a, I: Iterator<Item = HybridEncoded<'a>>> FilteredHybridBitmapIter<'a, I> {
+    pub fn new(iter: I, selected_rows: VecDeque<Interval>) -> Self {
+        let total_items = selected_rows.iter().map(|x| x.length).sum();
+        Self {
+            iter,
+            current: None,
+            current_interval: None,
+            selected_rows,
+            current_items_in_runs: 0,
+            total_items,
+        }
+    }
+
+    fn advance_current_interval(&mut self, length: usize) {
+        if let Some(interval) = &mut self.current_interval {
+            interval.start += length;
+            interval.length -= length;
+            self.total_items -= length;
+        }
+    }
+
+    /// Returns the number of elements remaining. Note that each run
+    /// of the iterator contains more than one element - this is is _not_ equivalent to size_hint.
+    pub fn len(&self) -> usize {
+        self.total_items
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl<'a, I: Iterator<Item = HybridEncoded<'a>>> Iterator for FilteredHybridBitmapIter<'a, I> {
+    type Item = FilteredHybridEncoded<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let interval = if let Some(interval) = self.current_interval {
+            interval
+        } else {
+            self.current_interval = self.selected_rows.pop_front();
+            self.current_interval?; // case where iteration finishes
+            return self.next();
+        };
+
+        let (run, offset) = if let Some((run, offset)) = self.current {
+            (run, offset)
+        } else {
+            // a new run
+            let run = self.iter.next()?; // no run => something wrong since intervals should only slice items up all runs' length
+            self.current = Some((run, 0));
+            return self.next();
+        };
+
+        // one of three things can happen:
+        // * the start of the interval is not aligned wirh the start of the run => issue a `Skipped` and advance the run / next run
+        // * the run contains this interval => consume the interval and keep the run
+        // * the run contains part of this interval => consume the run and keep the interval
+
+        match run {
+            HybridEncoded::Repeated(is_set, full_run_length) => {
+                let run_length = full_run_length - offset;
+                // interval.start is from the start of the first run; discount `current_items_in_runs`
+                // to get the start from the current run's offset
+                let interval_start = interval.start - self.current_items_in_runs;
+
+                if interval_start > 0 {
+                    // we need to skip values from the run
+                    let to_skip = interval_start;
+
+                    // we only skip up to a run (yield a single skip per multiple runs)
+                    let max_skip = full_run_length - offset;
+                    let to_skip = to_skip.min(max_skip);
+
+                    let set = if is_set { to_skip } else { 0 };
+
+                    self.current_items_in_runs += to_skip;
+
+                    self.current = if to_skip == max_skip {
+                        None
+                    } else {
+                        Some((run, offset + to_skip))
+                    };
+
+                    return Some(FilteredHybridEncoded::Skipped(set));
+                };
+
+                // slice the bitmap according to current interval
+                // note that interval start is from the start of the first run.
+                let new_offset = offset + interval_start;
+
+                if interval_start > run_length {
+                    let set = if is_set { run_length } else { 0 };
+
+                    self.advance_current_interval(run_length);
+                    self.current_items_in_runs += run_length;
+                    self.current = None;
+                    Some(FilteredHybridEncoded::Skipped(set))
+                } else {
+                    let length = if run_length > interval.length {
+                        // interval is fully consumed
+                        self.current_items_in_runs += interval.length;
+
+                        // fetch next interval
+                        self.total_items -= interval.length;
+                        self.current_interval = self.selected_rows.pop_front();
+
+                        self.current = Some((run, offset + interval.length));
+
+                        interval.length
+                    } else {
+                        // the run is consumed and the interval is shortened accordingly
+                        self.current_items_in_runs += run_length;
+
+                        // the interval may cover two runs; shorten the length
+                        // to its maximum allowed for this run
+                        let length = run_length.min(full_run_length - new_offset);
+
+                        self.advance_current_interval(length);
+
+                        self.current = None;
+                        length
+                    };
+                    Some(FilteredHybridEncoded::Repeated { is_set, length })
+                }
+            }
+            HybridEncoded::Bitmap(values, full_run_length) => {
+                let run_length = full_run_length - offset;
+                // interval.start is from the start of the first run; discount `current_items_in_runs`
+                // to get the start from the current run's offset
+                let interval_start = interval.start - self.current_items_in_runs;
+
+                if interval_start > 0 {
+                    // we need to skip values from the run
+                    let to_skip = interval_start;
+
+                    // we only skip up to a run (yield a single skip per multiple runs)
+                    let max_skip = full_run_length - offset;
+                    let to_skip = to_skip.min(max_skip);
+
+                    let set = is_set_count(values, offset, to_skip);
+
+                    self.current_items_in_runs += to_skip;
+
+                    self.current = if to_skip == max_skip {
+                        None
+                    } else {
+                        Some((run, offset + to_skip))
+                    };
+
+                    return Some(FilteredHybridEncoded::Skipped(set));
+                };
+
+                // slice the bitmap according to current interval
+                // note that interval start is from the start of the first run.
+                let new_offset = offset + interval_start;
+
+                if interval_start > run_length {
+                    let set = is_set_count(values, offset, full_run_length);
+
+                    self.advance_current_interval(run_length);
+                    self.current_items_in_runs += run_length;
+                    self.current = None;
+                    Some(FilteredHybridEncoded::Skipped(set))
+                } else {
+                    let length = if run_length > interval.length {
+                        // interval is fully consumed
+                        self.current_items_in_runs += interval.length;
+
+                        // fetch next interval
+                        self.total_items -= interval.length;
+                        self.current_interval = self.selected_rows.pop_front();
+
+                        self.current = Some((run, offset + interval.length));
+
+                        interval.length
+                    } else {
+                        // the run is consumed and the interval is shortened accordingly
+                        self.current_items_in_runs += run_length;
+
+                        // the interval may cover two runs; shorten the length
+                        // to its maximum allowed for this run
+                        let length = run_length.min(full_run_length - new_offset);
+
+                        self.advance_current_interval(length);
+
+                        self.current = None;
+                        length
+                    };
+                    Some(FilteredHybridEncoded::Bitmap {
+                        values,
+                        offset: new_offset,
+                        length,
+                    })
+                }
+            }
+        }
+    }
+}

--- a/src/deserialize/mod.rs
+++ b/src/deserialize/mod.rs
@@ -1,5 +1,6 @@
 mod binary;
 mod boolean;
+mod filtered_rle;
 mod fixed_len;
 mod hybrid_rle;
 mod native;
@@ -7,6 +8,7 @@ mod utils;
 
 pub use binary::*;
 pub use boolean::*;
+pub use filtered_rle::*;
 pub use fixed_len::*;
 pub use hybrid_rle::*;
 pub use native::*;

--- a/src/deserialize/utils.rs
+++ b/src/deserialize/utils.rs
@@ -89,16 +89,19 @@ pub struct SliceFilteredIter<I> {
     selected_rows: VecDeque<Interval>,
     current_remaining: usize,
     current: usize, // position in the slice
+    total_length: usize,
 }
 
 impl<I> SliceFilteredIter<I> {
     /// Return a new [`SliceFilteredIter`]
     pub fn new(iter: I, selected_rows: VecDeque<Interval>) -> Self {
+        let total_length = selected_rows.iter().map(|i| i.length).sum();
         Self {
             iter,
             selected_rows,
             current_remaining: 0,
             current: 0,
+            total_length,
         }
     }
 }
@@ -110,19 +113,26 @@ impl<T, I: Iterator<Item = T>> Iterator for SliceFilteredIter<I> {
     fn next(&mut self) -> Option<Self::Item> {
         if self.current_remaining == 0 {
             if let Some(interval) = self.selected_rows.pop_front() {
-                // skip the hole between the previous start end this start
+                // skip the hole between the previous start and this start
                 // (start + length) - start
                 let item = self.iter.nth(interval.start - self.current);
                 self.current = interval.start + interval.length;
                 self.current_remaining = interval.length - 1;
+                self.total_length -= 1;
                 item
             } else {
                 None
             }
         } else {
             self.current_remaining -= 1;
+            self.total_length -= 1;
             self.iter.next()
         }
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.total_length, Some(self.total_length))
     }
 }
 
@@ -143,13 +153,14 @@ mod test {
         ];
 
         let a: VecDeque<Interval> = intervals.clone().into_iter().collect();
-        let a = SliceFilteredIter::new(iter, a);
+        let mut a = SliceFilteredIter::new(iter, a);
 
         let expected: Vec<usize> = intervals
             .into_iter()
             .flat_map(|interval| interval.start..(interval.start + interval.length))
             .collect();
 
-        assert_eq!(expected, a.collect::<Vec<_>>());
+        assert_eq!(expected, a.by_ref().collect::<Vec<_>>());
+        assert_eq!((0, Some(0)), a.size_hint());
     }
 }

--- a/tests/it/read/deserialize.rs
+++ b/tests/it/read/deserialize.rs
@@ -1,0 +1,312 @@
+use parquet2::deserialize::{FilteredHybridBitmapIter, FilteredHybridEncoded, HybridEncoded};
+use parquet2::indexes::Interval;
+
+#[test]
+fn bitmap_incomplete() {
+    let mut iter = FilteredHybridBitmapIter::new(
+        vec![HybridEncoded::Bitmap(&[0b01000011], 7)].into_iter(),
+        vec![Interval::new(1, 2)].into(),
+    );
+    let a = iter.by_ref().collect::<Vec<_>>();
+    assert_eq!(iter.len(), 0);
+    assert_eq!(
+        a,
+        vec![
+            FilteredHybridEncoded::Skipped(1),
+            FilteredHybridEncoded::Bitmap {
+                values: &[0b01000011],
+                offset: 1,
+                length: 2,
+            }
+        ]
+    );
+}
+
+#[test]
+fn bitmap_complete() {
+    let mut iter = FilteredHybridBitmapIter::new(
+        vec![HybridEncoded::Bitmap(&[0b01000011], 8)].into_iter(),
+        vec![Interval::new(0, 8)].into(),
+    );
+    let a = iter.by_ref().collect::<Vec<_>>();
+    assert_eq!(iter.len(), 0);
+    assert_eq!(
+        a,
+        vec![FilteredHybridEncoded::Bitmap {
+            values: &[0b01000011],
+            offset: 0,
+            length: 8,
+        }]
+    );
+}
+
+#[test]
+fn bitmap_interval_incomplete() {
+    let mut iter = FilteredHybridBitmapIter::new(
+        vec![
+            HybridEncoded::Bitmap(&[0b01000011], 8),
+            HybridEncoded::Bitmap(&[0b11111111], 8),
+        ]
+        .into_iter(),
+        vec![Interval::new(0, 10)].into(),
+    );
+    let a = iter.by_ref().collect::<Vec<_>>();
+    assert_eq!(iter.len(), 0);
+    assert_eq!(
+        a,
+        vec![
+            FilteredHybridEncoded::Bitmap {
+                values: &[0b01000011],
+                offset: 0,
+                length: 8,
+            },
+            FilteredHybridEncoded::Bitmap {
+                values: &[0b11111111],
+                offset: 0,
+                length: 2,
+            }
+        ]
+    );
+}
+
+#[test]
+fn bitmap_interval_run_incomplete() {
+    let mut iter = FilteredHybridBitmapIter::new(
+        vec![
+            HybridEncoded::Bitmap(&[0b01100011], 8),
+            HybridEncoded::Bitmap(&[0b11111111], 8),
+        ]
+        .into_iter(),
+        vec![Interval::new(0, 5), Interval::new(7, 4)].into(),
+    );
+    let a = iter.by_ref().collect::<Vec<_>>();
+    assert_eq!(iter.len(), 0);
+    assert_eq!(
+        a,
+        vec![
+            FilteredHybridEncoded::Bitmap {
+                values: &[0b01100011],
+                offset: 0,
+                length: 5,
+            },
+            FilteredHybridEncoded::Skipped(2),
+            FilteredHybridEncoded::Bitmap {
+                values: &[0b01100011],
+                offset: 7,
+                length: 1,
+            },
+            FilteredHybridEncoded::Bitmap {
+                values: &[0b11111111],
+                offset: 0,
+                length: 3,
+            }
+        ]
+    );
+}
+
+#[test]
+fn bitmap_interval_run_skipped() {
+    let mut iter = FilteredHybridBitmapIter::new(
+        vec![
+            HybridEncoded::Bitmap(&[0b01100011], 8),
+            HybridEncoded::Bitmap(&[0b11111111], 8),
+        ]
+        .into_iter(),
+        vec![Interval::new(9, 2)].into(),
+    );
+    let a = iter.by_ref().collect::<Vec<_>>();
+    assert_eq!(iter.len(), 0);
+    assert_eq!(
+        a,
+        vec![
+            FilteredHybridEncoded::Skipped(4),
+            FilteredHybridEncoded::Skipped(1),
+            FilteredHybridEncoded::Bitmap {
+                values: &[0b11111111],
+                offset: 1,
+                length: 2,
+            },
+        ]
+    );
+}
+
+#[test]
+fn bitmap_interval_run_offset_skipped() {
+    let mut iter = FilteredHybridBitmapIter::new(
+        vec![
+            HybridEncoded::Bitmap(&[0b01100011], 8),
+            HybridEncoded::Bitmap(&[0b11111111], 8),
+        ]
+        .into_iter(),
+        vec![Interval::new(0, 1), Interval::new(9, 2)].into(),
+    );
+    let a = iter.by_ref().collect::<Vec<_>>();
+    assert_eq!(iter.len(), 0);
+    assert_eq!(
+        a,
+        vec![
+            FilteredHybridEncoded::Bitmap {
+                values: &[0b01100011],
+                offset: 0,
+                length: 1,
+            },
+            FilteredHybridEncoded::Skipped(3),
+            FilteredHybridEncoded::Skipped(1),
+            FilteredHybridEncoded::Bitmap {
+                values: &[0b11111111],
+                offset: 1,
+                length: 2,
+            },
+        ]
+    );
+}
+
+#[test]
+fn repeated_incomplete() {
+    let mut iter = FilteredHybridBitmapIter::new(
+        vec![HybridEncoded::Repeated(true, 7)].into_iter(),
+        vec![Interval::new(1, 2)].into(),
+    );
+    let a = iter.by_ref().collect::<Vec<_>>();
+    assert_eq!(iter.len(), 0);
+    assert_eq!(
+        a,
+        vec![
+            FilteredHybridEncoded::Skipped(1),
+            FilteredHybridEncoded::Repeated {
+                is_set: true,
+                length: 2,
+            }
+        ]
+    );
+}
+
+#[test]
+fn repeated_complete() {
+    let mut iter = FilteredHybridBitmapIter::new(
+        vec![HybridEncoded::Repeated(true, 8)].into_iter(),
+        vec![Interval::new(0, 8)].into(),
+    );
+    let a = iter.by_ref().collect::<Vec<_>>();
+    assert_eq!(iter.len(), 0);
+    assert_eq!(
+        a,
+        vec![FilteredHybridEncoded::Repeated {
+            is_set: true,
+            length: 8,
+        }]
+    );
+}
+
+#[test]
+fn repeated_interval_incomplete() {
+    let mut iter = FilteredHybridBitmapIter::new(
+        vec![
+            HybridEncoded::Repeated(true, 8),
+            HybridEncoded::Repeated(false, 8),
+        ]
+        .into_iter(),
+        vec![Interval::new(0, 10)].into(),
+    );
+    let a = iter.by_ref().collect::<Vec<_>>();
+    assert_eq!(iter.len(), 0);
+    assert_eq!(
+        a,
+        vec![
+            FilteredHybridEncoded::Repeated {
+                is_set: true,
+                length: 8,
+            },
+            FilteredHybridEncoded::Repeated {
+                is_set: false,
+                length: 2,
+            }
+        ]
+    );
+}
+
+#[test]
+fn repeated_interval_run_incomplete() {
+    let mut iter = FilteredHybridBitmapIter::new(
+        vec![
+            HybridEncoded::Repeated(true, 8),
+            HybridEncoded::Repeated(false, 8),
+        ]
+        .into_iter(),
+        vec![Interval::new(0, 5), Interval::new(7, 4)].into(),
+    );
+    let a = iter.by_ref().collect::<Vec<_>>();
+    assert_eq!(iter.len(), 0);
+    assert_eq!(
+        a,
+        vec![
+            FilteredHybridEncoded::Repeated {
+                is_set: true,
+                length: 5,
+            },
+            FilteredHybridEncoded::Skipped(2),
+            FilteredHybridEncoded::Repeated {
+                is_set: true,
+                length: 1,
+            },
+            FilteredHybridEncoded::Repeated {
+                is_set: false,
+                length: 3,
+            }
+        ]
+    );
+}
+
+#[test]
+fn repeated_interval_run_skipped() {
+    let mut iter = FilteredHybridBitmapIter::new(
+        vec![
+            HybridEncoded::Repeated(true, 8),
+            HybridEncoded::Repeated(false, 8),
+        ]
+        .into_iter(),
+        vec![Interval::new(9, 2)].into(),
+    );
+    let a = iter.by_ref().collect::<Vec<_>>();
+    assert_eq!(iter.len(), 0);
+    assert_eq!(
+        a,
+        vec![
+            FilteredHybridEncoded::Skipped(8),
+            FilteredHybridEncoded::Skipped(0),
+            FilteredHybridEncoded::Repeated {
+                is_set: false,
+                length: 2,
+            },
+        ]
+    );
+}
+
+#[test]
+fn repeated_interval_run_offset_skipped() {
+    let mut iter = FilteredHybridBitmapIter::new(
+        vec![
+            HybridEncoded::Repeated(true, 8),
+            HybridEncoded::Repeated(false, 8),
+        ]
+        .into_iter(),
+        vec![Interval::new(0, 1), Interval::new(9, 2)].into(),
+    );
+    let a = iter.by_ref().collect::<Vec<_>>();
+    assert_eq!(iter.len(), 0);
+    assert_eq!(
+        a,
+        vec![
+            FilteredHybridEncoded::Repeated {
+                is_set: true,
+                length: 1,
+            },
+            FilteredHybridEncoded::Skipped(7),
+            FilteredHybridEncoded::Skipped(0),
+            FilteredHybridEncoded::Repeated {
+                is_set: false,
+                length: 2,
+            },
+        ]
+    );
+}

--- a/tests/it/read/mod.rs
+++ b/tests/it/read/mod.rs
@@ -3,6 +3,7 @@
 /// but OTOH it has no external dependencies and is very familiar to Rust developers.
 mod binary;
 mod boolean;
+mod deserialize;
 mod fixed_binary;
 mod indexes;
 mod primitive;

--- a/tests/it/read/utils.rs
+++ b/tests/it/read/utils.rs
@@ -23,8 +23,8 @@ fn deserialize_bitmap<C: Clone, I: Iterator<Item = C>>(
     let mut deserialized = Vec::with_capacity(validity.len());
 
     validity.for_each(|run| match run {
-        HybridEncoded::Bitmap(bitmap, offset, length) => {
-            BitmapIter::new(bitmap, offset, length)
+        HybridEncoded::Bitmap(bitmap, length) => {
+            BitmapIter::new(bitmap, 0, length)
                 .into_iter()
                 .for_each(|x| {
                     if x {


### PR DESCRIPTION
This PR adds an iterator adapter that can skip sections of hybrid-RLE encoded definition levels used in optional data pages.

This adapter is a specialization suitable for index-reading pages to in-memory formats that use bitmaps (like arrow).
