### PR TITLE
Adds zstd compression levels to parquet2.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,8 @@ jobs:
           deactivate
       - name: Run
         run: cargo test
+      - name: Run lz4-flex
+        run: cargo test --no-default-features --features lz4_flex,bloom_filter,stream,snappy,brotli,zstd,gzip
 
   clippy:
     name: Clippy

--- a/.github_changelog_generator
+++ b/.github_changelog_generator
@@ -1,5 +1,5 @@
-since-tag=v0.10.2
-future-release=v0.10.3
+since-tag=v0.10.3
+future-release=v0.11.0
 pr-wo-labels=false
 exclude-labels=no-changelog,question
 add-sections={"features":{"prefix":"**Enhancements:**","labels":["enhancement"]}, "documentation":{"prefix":"**Documentation updates:**","labels":["documentation"]}, "testing":{"prefix":"**Testing updates:**","labels":["testing"]}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog
 
+## [v0.11.0](https://github.com/jorgecarleitao/parquet2/tree/v0.11.0) (2022-04-15)
+
+[Full Changelog](https://github.com/jorgecarleitao/parquet2/compare/v0.10.3...v0.11.0)
+
+**Breaking changes:**
+
+- Renamed `ParquetError` to `Error` [\#109](https://github.com/jorgecarleitao/parquet2/issues/109)
+- Made `.end` not consume the parquet `FileWriter` [\#127](https://github.com/jorgecarleitao/parquet2/pull/127) ([jorgecarleitao](https://github.com/jorgecarleitao))
+- Removed `compression` from `WriteOptions` [\#125](https://github.com/jorgecarleitao/parquet2/pull/125) ([kornholi](https://github.com/kornholi))
+- Simplified API and converted some panics on read to errors [\#112](https://github.com/jorgecarleitao/parquet2/pull/112) ([jorgecarleitao](https://github.com/jorgecarleitao))
+- Improved typing to reduce clones and use of unwraps [\#106](https://github.com/jorgecarleitao/parquet2/pull/106) ([jorgecarleitao](https://github.com/jorgecarleitao))
+- Simplified `PageIterator` [\#103](https://github.com/jorgecarleitao/parquet2/pull/103) ([jorgecarleitao](https://github.com/jorgecarleitao))
+
+**New features:**
+
+- Added support for page-level filter pushdown \(indexes\) [\#102](https://github.com/jorgecarleitao/parquet2/issues/102)
+- Added support for bloom filters [\#98](https://github.com/jorgecarleitao/parquet2/issues/98)
+- Added optional support for LZ4 via LZ4-flex crate \(thus enabling wasm\) [\#124](https://github.com/jorgecarleitao/parquet2/pull/124) ([jorgecarleitao](https://github.com/jorgecarleitao))
+- Added support for page-level filter pushdown \(column and offset indexes\) [\#107](https://github.com/jorgecarleitao/parquet2/pull/107) ([jorgecarleitao](https://github.com/jorgecarleitao))
+- Added support to read column and page indexes [\#100](https://github.com/jorgecarleitao/parquet2/pull/100) ([jorgecarleitao](https://github.com/jorgecarleitao))
+
+**Fixed bugs:**
+
+- Fixed minimum version for LZ4 [\#122](https://github.com/jorgecarleitao/parquet2/pull/122) ([kornholi](https://github.com/kornholi))
+- Fixed Lz4Raw compression error \(if input is tiny\)  [\#118](https://github.com/jorgecarleitao/parquet2/pull/118) ([dantengsky](https://github.com/dantengsky))
+- Fixed LZ4 [\#95](https://github.com/jorgecarleitao/parquet2/pull/95) ([jorgecarleitao](https://github.com/jorgecarleitao))
+
+**Enhancements:**
+
+- Made offsets be always written [\#123](https://github.com/jorgecarleitao/parquet2/pull/123) ([jorgecarleitao](https://github.com/jorgecarleitao))
+- Added specialized deserialization of one-level filtered pages [\#120](https://github.com/jorgecarleitao/parquet2/pull/120) ([jorgecarleitao](https://github.com/jorgecarleitao))
+- Added support to read and use bloom filters [\#99](https://github.com/jorgecarleitao/parquet2/pull/99) ([jorgecarleitao](https://github.com/jorgecarleitao))
+- Added `ordinal` and `total_compressed_size` to column meta [\#96](https://github.com/jorgecarleitao/parquet2/pull/96) ([jorgecarleitao](https://github.com/jorgecarleitao))
+- Added non-consuming function to get values of delta-decoder [\#94](https://github.com/jorgecarleitao/parquet2/pull/94) ([jorgecarleitao](https://github.com/jorgecarleitao))
+- Disabled bitpacking default-features and upgraded to edition 2021 [\#93](https://github.com/jorgecarleitao/parquet2/pull/93) ([light4](https://github.com/light4))
+
+**Documentation updates:**
+
+- Fix deployment of guide [\#115](https://github.com/jorgecarleitao/parquet2/pull/115) ([jorgecarleitao](https://github.com/jorgecarleitao))
+
+**Testing updates:**
+
+- Added tests for reducing statistics [\#116](https://github.com/jorgecarleitao/parquet2/pull/116) ([jorgecarleitao](https://github.com/jorgecarleitao))
+- Simplified tests [\#104](https://github.com/jorgecarleitao/parquet2/pull/104) ([jorgecarleitao](https://github.com/jorgecarleitao))
+
 ## [v0.10.3](https://github.com/jorgecarleitao/parquet2/tree/v0.10.3) (2022-03-03)
 
 [Full Changelog](https://github.com/jorgecarleitao/parquet2/compare/v0.10.2...v0.10.3)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ brotli = { version = "^3.3", optional = true }
 flate2 = { version = "^1.0", optional = true }
 lz4 = { version = "1.23.3", optional = true }
 zstd = { version = "^0.11", optional = true, default-features = false }
+lz4_flex = { version = "^0.9.2", optional = true }
 
 xxhash-rust = { version="0.8.3", optional = true, features = ["xxh64"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parquet2"
-version = "0.10.3"
+version = "0.11.0"
 license = "Apache-2.0"
 description = "Safe implementation of parquet IO."
 authors = ["Jorge C. Leitao <jorgecarleitao@gmail.com", "Apache Arrow <dev@arrow.apache.org>"]

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -1,5 +1,5 @@
 //! Functionality to compress and decompress data according to the parquet specification
-pub use super::parquet_bridge::Compression;
+pub use super::parquet_bridge::{Compression, ZstdLevel};
 
 use crate::error::{Error, Result};
 
@@ -93,12 +93,13 @@ pub fn compress(
             "compress to lz4".to_string(),
         )),
         #[cfg(feature = "zstd")]
-        Compression::Zstd => {
+        Compression::Zstd(level) => {
             use std::io::Write;
-            /// Compression level (1-21) for ZSTD. Choose 1 here for better compression speed.
-            const ZSTD_COMPRESSION_LEVEL: i32 = 1;
+            let level = level
+                .map(|v| v.compression_level())
+                .unwrap_or(zstd::DEFAULT_COMPRESSION_LEVEL);
 
-            let mut encoder = zstd::Encoder::new(output_buf, ZSTD_COMPRESSION_LEVEL)?;
+            let mut encoder = zstd::Encoder::new(output_buf, level)?;
             encoder.write_all(input_buf)?;
             match encoder.finish() {
                 Ok(_) => Ok(()),
@@ -180,7 +181,7 @@ pub fn decompress(compression: Compression, input_buf: &[u8], output_buf: &mut [
             "decompress with lz4".to_string(),
         )),
         #[cfg(feature = "zstd")]
-        Compression::Zstd => {
+        Compression::Zstd(_) => {
             use std::io::Read;
             let mut decoder = zstd::Decoder::new(input_buf)?;
             decoder.read_exact(output_buf).map_err(|e| e.into())
@@ -248,7 +249,16 @@ mod tests {
     }
 
     #[test]
-    fn test_codec_zstd() {
-        test_codec(Compression::Zstd);
+    fn test_codec_zstd_default() {
+        test_codec(Compression::Zstd(None));
+    }
+
+    #[test]
+    fn test_codec_zstd_low_compression() {
+        test_codec(Compression::Zstd(Some(ZstdLevel::try_new(1).unwrap())));
+    }
+    #[test]
+    fn test_codec_zstd_high_compression() {
+        test_codec(Compression::Zstd(Some(ZstdLevel::try_new(21).unwrap())));
     }
 }

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -1,6 +1,5 @@
 //! Functionality to compress and decompress data according to the parquet specification
-pub use super::parquet_bridge::{Compression, ZstdLevel};
-
+pub use super::parquet_bridge::{Compression, CompressionEncode, ZstdLevel};
 use crate::error::{Error, Result};
 
 /// Compresses data stored in slice `input_buf` and writes the compressed result
@@ -8,13 +7,13 @@ use crate::error::{Error, Result};
 /// Note that you'll need to call `clear()` before reusing the same `output_buf`
 /// across different `compress` calls.
 pub fn compress(
-    compression: Compression,
+    compression: CompressionEncode,
     input_buf: &[u8],
     output_buf: &mut Vec<u8>,
 ) -> Result<()> {
     match compression {
         #[cfg(feature = "brotli")]
-        Compression::Brotli => {
+        CompressionEncode::Brotli => {
             use std::io::Write;
             const BROTLI_DEFAULT_BUFFER_SIZE: usize = 4096;
             const BROTLI_DEFAULT_COMPRESSION_QUALITY: u32 = 1; // supported levels 0-9
@@ -30,24 +29,24 @@ pub fn compress(
             encoder.flush().map_err(|e| e.into())
         }
         #[cfg(not(feature = "brotli"))]
-        Compression::Brotli => Err(Error::FeatureNotActive(
+        CompressionEncode::Brotli => Err(Error::FeatureNotActive(
             crate::error::Feature::Brotli,
             "compress to brotli".to_string(),
         )),
         #[cfg(feature = "gzip")]
-        Compression::Gzip => {
+        CompressionEncode::Gzip => {
             use std::io::Write;
             let mut encoder = flate2::write::GzEncoder::new(output_buf, Default::default());
             encoder.write_all(input_buf)?;
             encoder.try_finish().map_err(|e| e.into())
         }
         #[cfg(not(feature = "gzip"))]
-        Compression::Gzip => Err(Error::FeatureNotActive(
+        CompressionEncode::Gzip => Err(Error::FeatureNotActive(
             crate::error::Feature::Gzip,
             "compress to gzip".to_string(),
         )),
         #[cfg(feature = "snappy")]
-        Compression::Snappy => {
+        CompressionEncode::Snappy => {
             use snap::raw::{max_compress_len, Encoder};
 
             let output_buf_len = output_buf.len();
@@ -58,12 +57,12 @@ pub fn compress(
             Ok(())
         }
         #[cfg(not(feature = "snappy"))]
-        Compression::Snappy => Err(Error::FeatureNotActive(
+        CompressionEncode::Snappy => Err(Error::FeatureNotActive(
             crate::error::Feature::Snappy,
             "compress to snappy".to_string(),
         )),
         #[cfg(all(feature = "lz4_flex", not(feature = "lz4")))]
-        Compression::Lz4Raw => {
+        CompressionEncode::Lz4Raw => {
             let output_buf_len = output_buf.len();
             let required_len = lz4_flex::block::get_maximum_output_size(input_buf.len());
             output_buf.resize(output_buf_len + required_len, 0);
@@ -74,7 +73,7 @@ pub fn compress(
             Ok(())
         }
         #[cfg(feature = "lz4")]
-        Compression::Lz4Raw => {
+        CompressionEncode::Lz4Raw => {
             let output_buf_len = output_buf.len();
             let required_len = lz4::block::compress_bound(input_buf.len())?;
             output_buf.resize(required_len, 0);
@@ -88,12 +87,12 @@ pub fn compress(
             Ok(())
         }
         #[cfg(all(not(feature = "lz4"), not(feature = "lz4_flex")))]
-        Compression::Lz4Raw => Err(Error::FeatureNotActive(
+        CompressionEncode::Lz4Raw => Err(Error::FeatureNotActive(
             crate::error::Feature::Lz4,
             "compress to lz4".to_string(),
         )),
         #[cfg(feature = "zstd")]
-        Compression::Zstd(level) => {
+        CompressionEncode::Zstd(level) => {
             use std::io::Write;
             let level = level
                 .map(|v| v.compression_level())
@@ -107,11 +106,11 @@ pub fn compress(
             }
         }
         #[cfg(not(feature = "zstd"))]
-        Compression::Zstd => Err(Error::FeatureNotActive(
+        CompressionEncode::Zstd => Err(Error::FeatureNotActive(
             crate::error::Feature::Zstd,
             "compress to zstd".to_string(),
         )),
-        Compression::Uncompressed => {
+        CompressionEncode::Uncompressed => {
             Err(general_err!("Compressing without compression is not valid"))
         }
         _ => Err(general_err!(
@@ -181,7 +180,7 @@ pub fn decompress(compression: Compression, input_buf: &[u8], output_buf: &mut [
             "decompress with lz4".to_string(),
         )),
         #[cfg(feature = "zstd")]
-        Compression::Zstd(_) => {
+        Compression::Zstd => {
             use std::io::Read;
             let mut decoder = zstd::Decoder::new(input_buf)?;
             decoder.read_exact(output_buf).map_err(|e| e.into())
@@ -205,7 +204,7 @@ pub fn decompress(compression: Compression, input_buf: &[u8], output_buf: &mut [
 mod tests {
     use super::*;
 
-    fn test_roundtrip(c: Compression, data: &[u8]) {
+    fn test_roundtrip(c: CompressionEncode, data: &[u8]) {
         let offset = 2;
 
         // Compress to a buffer that already has data is possible
@@ -216,11 +215,12 @@ mod tests {
         assert!(compressed.len() - 2 < data.len());
 
         let mut decompressed = vec![0; data.len()];
-        decompress(c, &compressed[offset..], &mut decompressed).expect("Error when decompressing");
+        decompress(c.into(), &compressed[offset..], &mut decompressed)
+            .expect("Error when decompressing");
         assert_eq!(data, decompressed.as_slice());
     }
 
-    fn test_codec(c: Compression) {
+    fn test_codec(c: CompressionEncode) {
         let sizes = vec![10000, 100000];
         for size in sizes {
             let data = (0..size).map(|x| (x % 255) as u8).collect::<Vec<_>>();
@@ -230,35 +230,39 @@ mod tests {
 
     #[test]
     fn test_codec_snappy() {
-        test_codec(Compression::Snappy);
+        test_codec(CompressionEncode::Snappy);
     }
 
     #[test]
     fn test_codec_gzip() {
-        test_codec(Compression::Gzip);
+        test_codec(CompressionEncode::Gzip);
     }
 
     #[test]
     fn test_codec_brotli() {
-        test_codec(Compression::Brotli);
+        test_codec(CompressionEncode::Brotli);
     }
 
     #[test]
     fn test_codec_lz4() {
-        test_codec(Compression::Lz4Raw);
+        test_codec(CompressionEncode::Lz4Raw);
     }
 
     #[test]
     fn test_codec_zstd_default() {
-        test_codec(Compression::Zstd(None));
+        test_codec(CompressionEncode::Zstd(None));
     }
 
     #[test]
     fn test_codec_zstd_low_compression() {
-        test_codec(Compression::Zstd(Some(ZstdLevel::try_new(1).unwrap())));
+        test_codec(CompressionEncode::Zstd(Some(
+            ZstdLevel::try_new(1).unwrap(),
+        )));
     }
     #[test]
     fn test_codec_zstd_high_compression() {
-        test_codec(Compression::Zstd(Some(ZstdLevel::try_new(21).unwrap())));
+        test_codec(CompressionEncode::Zstd(Some(
+            ZstdLevel::try_new(21).unwrap(),
+        )));
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -64,6 +64,20 @@ impl From<snap::Error> for Error {
     }
 }
 
+#[cfg(feature = "lz4_flex")]
+impl From<lz4_flex::block::DecompressError> for Error {
+    fn from(e: lz4_flex::block::DecompressError) -> Error {
+        Error::General(format!("underlying lz4_flex error: {}", e))
+    }
+}
+
+#[cfg(feature = "lz4_flex")]
+impl From<lz4_flex::block::CompressError> for Error {
+    fn from(e: lz4_flex::block::CompressError) -> Error {
+        Error::General(format!("underlying lz4_flex error: {}", e))
+    }
+}
+
 impl From<parquet_format_async_temp::thrift::Error> for Error {
     fn from(e: parquet_format_async_temp::thrift::Error) -> Error {
         Error::General(format!("underlying thrift error: {}", e))

--- a/src/page/mod.rs
+++ b/src/page/mod.rs
@@ -277,6 +277,13 @@ impl CompressedPage {
         }
     }
 
+    pub(crate) fn compression(&self) -> Compression {
+        match self {
+            CompressedPage::Data(page) => page.compression(),
+            CompressedPage::Dict(page) => page.compression(),
+        }
+    }
+
     pub(crate) fn num_values(&self) -> usize {
         match self {
             CompressedPage::Data(page) => page.num_values(),

--- a/src/page/page_dict/mod.rs
+++ b/src/page/page_dict/mod.rs
@@ -42,7 +42,12 @@ pub struct CompressedDictPage {
 }
 
 impl CompressedDictPage {
-    pub fn new(buffer: Vec<u8>, compression: Compression, uncompressed_page_size: usize, num_values: usize) -> Self {
+    pub fn new(
+        buffer: Vec<u8>,
+        compression: Compression,
+        uncompressed_page_size: usize,
+        num_values: usize,
+    ) -> Self {
         Self {
             buffer,
             compression,

--- a/src/page/page_dict/mod.rs
+++ b/src/page/page_dict/mod.rs
@@ -36,17 +36,24 @@ impl EncodedDictPage {
 #[derive(Debug)]
 pub struct CompressedDictPage {
     pub(crate) buffer: Vec<u8>,
+    compression: Compression,
     pub(crate) num_values: usize,
     pub(crate) uncompressed_page_size: usize,
 }
 
 impl CompressedDictPage {
-    pub fn new(buffer: Vec<u8>, uncompressed_page_size: usize, num_values: usize) -> Self {
+    pub fn new(buffer: Vec<u8>, compression: Compression, uncompressed_page_size: usize, num_values: usize) -> Self {
         Self {
             buffer,
+            compression,
             uncompressed_page_size,
             num_values,
         }
+    }
+
+    /// The compression of the data in this page.
+    pub fn compression(&self) -> Compression {
+        self.compression
     }
 }
 

--- a/src/write/column_chunk.rs
+++ b/src/write/column_chunk.rs
@@ -10,7 +10,7 @@ use parquet_format_async_temp::{ColumnChunk, ColumnMetaData, Type};
 use crate::statistics::serialize_statistics;
 use crate::FallibleStreamingIterator;
 use crate::{
-    compression::CompressionEncode,
+    compression::Compression,
     encoding::Encoding,
     error::{Error, Result},
     metadata::ColumnDescriptor,
@@ -25,7 +25,6 @@ pub fn write_column_chunk<'a, W, E>(
     writer: &mut W,
     mut offset: u64,
     descriptor: &ColumnDescriptor,
-    compression: CompressionEncode,
     mut compressed_pages: DynStreamingIterator<'a, CompressedPage, E>,
 ) -> Result<(ColumnChunk, Vec<PageWriteSpec>, u64)>
 where
@@ -113,7 +112,7 @@ fn build_column_chunk(
     let compression = compression
         .into_iter()
         .next()
-        .unwrap_or(CompressionEncode::Uncompressed);
+        .unwrap_or(Compression::Uncompressed);
 
     // SPEC: the total compressed size is the total compressed size of each page + the header size
     let total_compressed_size = specs

--- a/src/write/column_chunk.rs
+++ b/src/write/column_chunk.rs
@@ -129,7 +129,7 @@ fn build_column_chunk(
             }
         })
         .sum();
-    let encodings = specs
+    let mut encodings = specs
         .iter()
         .flat_map(|spec| {
             let type_ = spec.header.type_.try_into().unwrap();
@@ -155,7 +155,10 @@ fn build_column_chunk(
         })
         .collect::<HashSet<_>>() // unique
         .into_iter() // to vec
-        .collect();
+        .collect::<Vec<_>>();
+
+    // Sort the encodings to have deterministic metadata
+    encodings.sort();
 
     let statistics = specs.iter().map(|x| &x.statistics).collect::<Vec<_>>();
     let statistics = reduce(&statistics)?;

--- a/src/write/column_chunk.rs
+++ b/src/write/column_chunk.rs
@@ -10,7 +10,7 @@ use parquet_format_async_temp::{ColumnChunk, ColumnMetaData, Type};
 use crate::statistics::serialize_statistics;
 use crate::FallibleStreamingIterator;
 use crate::{
-    compression::Compression,
+    compression::CompressionEncode,
     encoding::Encoding,
     error::{Error, Result},
     metadata::ColumnDescriptor,
@@ -25,6 +25,7 @@ pub fn write_column_chunk<'a, W, E>(
     writer: &mut W,
     mut offset: u64,
     descriptor: &ColumnDescriptor,
+    compression: CompressionEncode,
     mut compressed_pages: DynStreamingIterator<'a, CompressedPage, E>,
 ) -> Result<(ColumnChunk, Vec<PageWriteSpec>, u64)>
 where
@@ -112,7 +113,7 @@ fn build_column_chunk(
     let compression = compression
         .into_iter()
         .next()
-        .unwrap_or(Compression::Uncompressed);
+        .unwrap_or(CompressionEncode::Uncompressed);
 
     // SPEC: the total compressed size is the total compressed size of each page + the header size
     let total_compressed_size = specs

--- a/src/write/compression.rs
+++ b/src/write/compression.rs
@@ -69,6 +69,7 @@ fn compress_dict(
     }
     Ok(CompressedDictPage::new(
         compressed_buffer,
+        compression,
         uncompressed_page_size,
         num_values,
     ))

--- a/src/write/compression.rs
+++ b/src/write/compression.rs
@@ -1,6 +1,6 @@
 use crate::error::{Error, Result};
 use crate::page::{CompressedDictPage, CompressedPage, DataPageHeader, EncodedDictPage};
-use crate::parquet_bridge::Compression;
+use crate::parquet_bridge::CompressionEncode;
 use crate::FallibleStreamingIterator;
 use crate::{
     compression,
@@ -11,7 +11,7 @@ use crate::{
 fn compress_data(
     page: DataPage,
     mut compressed_buffer: Vec<u8>,
-    compression: Compression,
+    compression: CompressionEncode,
 ) -> Result<CompressedDataPage> {
     let DataPage {
         mut buffer,
@@ -21,7 +21,7 @@ fn compress_data(
         selected_rows,
     } = page;
     let uncompressed_page_size = buffer.len();
-    if compression != Compression::Uncompressed {
+    if compression != CompressionEncode::Uncompressed {
         match &header {
             DataPageHeader::V1(_) => {
                 compression::compress(compression, &buffer, &mut compressed_buffer)?;
@@ -44,7 +44,7 @@ fn compress_data(
     Ok(CompressedDataPage::new_read(
         header,
         compressed_buffer,
-        compression,
+        compression.into(),
         uncompressed_page_size,
         dictionary_page,
         descriptor,
@@ -55,14 +55,14 @@ fn compress_data(
 fn compress_dict(
     page: EncodedDictPage,
     mut compressed_buffer: Vec<u8>,
-    compression: Compression,
+    compression: CompressionEncode,
 ) -> Result<CompressedDictPage> {
     let EncodedDictPage {
         mut buffer,
         num_values,
     } = page;
     let uncompressed_page_size = buffer.len();
-    if compression != Compression::Uncompressed {
+    if compression != CompressionEncode::Uncompressed {
         compression::compress(compression, &buffer, &mut compressed_buffer)?;
     } else {
         std::mem::swap(&mut buffer, &mut compressed_buffer);
@@ -85,7 +85,7 @@ fn compress_dict(
 pub fn compress(
     page: EncodedPage,
     compressed_buffer: Vec<u8>,
-    compression: Compression,
+    compression: CompressionEncode,
 ) -> Result<CompressedPage> {
     match page {
         EncodedPage::Data(page) => {
@@ -101,19 +101,19 @@ pub fn compress(
 /// holding a reusable buffer ([`Vec<u8>`]) for compression.
 pub struct Compressor<I: Iterator<Item = Result<EncodedPage>>> {
     iter: I,
-    compression: Compression,
+    compression: CompressionEncode,
     buffer: Vec<u8>,
     current: Option<CompressedPage>,
 }
 
 impl<I: Iterator<Item = Result<EncodedPage>>> Compressor<I> {
     /// Creates a new [`Compressor`]
-    pub fn new_from_vec(iter: I, compression: Compression, buffer: Vec<u8>) -> Self {
+    pub fn new_from_vec(iter: I, compression: CompressionEncode, buffer: Vec<u8>) -> Self {
         Self::new(iter, compression, buffer)
     }
 
     /// Creates a new [`Compressor`]
-    pub fn new(iter: I, compression: Compression, buffer: Vec<u8>) -> Self {
+    pub fn new(iter: I, compression: CompressionEncode, buffer: Vec<u8>) -> Self {
         Self {
             iter,
             compression,

--- a/src/write/compression.rs
+++ b/src/write/compression.rs
@@ -69,7 +69,7 @@ fn compress_dict(
     }
     Ok(CompressedDictPage::new(
         compressed_buffer,
-        compression,
+        compression.into(),
         uncompressed_page_size,
         num_values,
     ))

--- a/src/write/file.rs
+++ b/src/write/file.rs
@@ -110,7 +110,6 @@ impl<W: Write> FileWriter<W> {
             &mut self.writer,
             self.offset,
             self.schema.columns(),
-            self.options.compression,
             row_group,
             ordinal,
         )?;

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -20,7 +20,6 @@ pub use file::FileWriter;
 
 pub use row_group::ColumnOffsetsMetadata;
 
-use crate::compression::Compression;
 use crate::page::CompressedPage;
 
 pub type RowGroupIter<'a, E> =
@@ -31,8 +30,6 @@ pub type RowGroupIter<'a, E> =
 pub struct WriteOptions {
     /// Whether to write statistics, including indexes
     pub write_statistics: bool,
-    /// Whether to use compression
-    pub compression: Compression,
     /// Which Parquet version to use
     pub version: Version,
 }

--- a/src/write/page.rs
+++ b/src/write/page.rs
@@ -225,12 +225,8 @@ mod tests {
 
     #[test]
     fn dict_too_many_values() {
-        let page = CompressedDictPage::new(
-            vec![],
-            Compression::Uncompressed,
-            0,
-            i32::MAX as usize + 1,
-        );
+        let page =
+            CompressedDictPage::new(vec![], Compression::Uncompressed, 0, i32::MAX as usize + 1);
         assert!(assemble_dict_page_header(&page).is_err());
     }
 }

--- a/src/write/stream.rs
+++ b/src/write/stream.rs
@@ -106,7 +106,6 @@ impl<W: AsyncWrite + Unpin + Send> FileStreamer<W> {
             &mut self.writer,
             self.offset,
             self.schema.columns(),
-            self.options.compression,
             row_group,
         )
         .await?;

--- a/tests/it/write/indexes.rs
+++ b/tests/it/write/indexes.rs
@@ -53,9 +53,9 @@ fn write_file() -> Result<Vec<u8>> {
 
     writer.start()?;
     writer.write(DynIter::new(columns))?;
-    let writer = writer.end(None)?.1;
+    writer.end(None)?;
 
-    Ok(writer.into_inner())
+    Ok(writer.into_inner().into_inner())
 }
 
 #[test]

--- a/tests/it/write/indexes.rs
+++ b/tests/it/write/indexes.rs
@@ -1,6 +1,6 @@
 use std::io::Cursor;
 
-use parquet2::compression::Compression;
+use parquet2::compression::CompressionEncode;
 use parquet2::error::Result;
 use parquet2::indexes::{
     select_pages, BoundaryOrder, Index, Interval, NativeIndex, PageIndex, PageLocation,
@@ -43,7 +43,7 @@ fn write_file() -> Result<Vec<u8>> {
 
     let pages = DynStreamingIterator::new(Compressor::new(
         DynIter::new(pages.into_iter()),
-        Compression::Uncompressed,
+        CompressionEncode::Uncompressed,
         vec![],
     ));
     let columns = std::iter::once(Ok(pages));

--- a/tests/it/write/indexes.rs
+++ b/tests/it/write/indexes.rs
@@ -25,7 +25,6 @@ fn write_file() -> Result<Vec<u8>> {
 
     let options = WriteOptions {
         write_statistics: true,
-        compression: Compression::Uncompressed,
         version: Version::V1,
     };
 
@@ -44,7 +43,7 @@ fn write_file() -> Result<Vec<u8>> {
 
     let pages = DynStreamingIterator::new(Compressor::new(
         DynIter::new(pages.into_iter()),
-        options.compression,
+        Compression::Uncompressed,
         vec![],
     ));
     let columns = std::iter::once(Ok(pages));

--- a/tests/it/write/mod.rs
+++ b/tests/it/write/mod.rs
@@ -50,7 +50,7 @@ async fn read_column_async<
     Ok((a, statistics))
 }
 
-fn test_column(column: &str, compression: Compression) -> Result<()> {
+fn test_column(column: &str, compression: CompressionEncode) -> Result<()> {
     let array = alltypes_plain(column);
 
     let options = WriteOptions {
@@ -108,68 +108,68 @@ fn test_column(column: &str, compression: Compression) -> Result<()> {
 
 #[test]
 fn int32() -> Result<()> {
-    test_column("id", Compression::Uncompressed)
+    test_column("id", CompressionEncode::Uncompressed)
 }
 
 #[test]
 fn int32_snappy() -> Result<()> {
-    test_column("id", Compression::Snappy)
+    test_column("id", CompressionEncode::Snappy)
 }
 
 #[test]
 fn int32_lz4() -> Result<()> {
-    test_column("id", Compression::Lz4Raw)
+    test_column("id", CompressionEncode::Lz4Raw)
 }
 
 #[test]
 fn int32_lz4_short_i32_array() -> Result<()> {
-    test_column("id-short-array", Compression::Lz4Raw)
+    test_column("id-short-array", CompressionEncode::Lz4Raw)
 }
 
 #[test]
 fn int32_brotli() -> Result<()> {
-    test_column("id", Compression::Brotli)
+    test_column("id", CompressionEncode::Brotli)
 }
 
 #[test]
 #[ignore = "Native boolean writer not yet implemented"]
 fn bool() -> Result<()> {
-    test_column("bool_col", Compression::Uncompressed)
+    test_column("bool_col", CompressionEncode::Uncompressed)
 }
 
 #[test]
 fn tinyint() -> Result<()> {
-    test_column("tinyint_col", Compression::Uncompressed)
+    test_column("tinyint_col", CompressionEncode::Uncompressed)
 }
 
 #[test]
 fn smallint_col() -> Result<()> {
-    test_column("smallint_col", Compression::Uncompressed)
+    test_column("smallint_col", CompressionEncode::Uncompressed)
 }
 
 #[test]
 fn int_col() -> Result<()> {
-    test_column("int_col", Compression::Uncompressed)
+    test_column("int_col", CompressionEncode::Uncompressed)
 }
 
 #[test]
 fn bigint_col() -> Result<()> {
-    test_column("bigint_col", Compression::Uncompressed)
+    test_column("bigint_col", CompressionEncode::Uncompressed)
 }
 
 #[test]
 fn float_col() -> Result<()> {
-    test_column("float_col", Compression::Uncompressed)
+    test_column("float_col", CompressionEncode::Uncompressed)
 }
 
 #[test]
 fn double_col() -> Result<()> {
-    test_column("double_col", Compression::Uncompressed)
+    test_column("double_col", CompressionEncode::Uncompressed)
 }
 
 #[test]
 fn string_col() -> Result<()> {
-    test_column("string_col", Compression::Uncompressed)
+    test_column("string_col", CompressionEncode::Uncompressed)
 }
 
 #[test]

--- a/tests/it/write/mod.rs
+++ b/tests/it/write/mod.rs
@@ -92,9 +92,9 @@ fn test_column(column: &str, compression: Compression) -> Result<()> {
 
     writer.start()?;
     writer.write(DynIter::new(columns))?;
-    let writer = writer.end(None)?.1;
+    writer.end(None)?;
 
-    let data = writer.into_inner();
+    let data = writer.into_inner().into_inner();
 
     let (result, statistics) = read_column(&mut Cursor::new(data))?;
     assert_eq!(array, result);
@@ -213,9 +213,9 @@ fn basic() -> Result<()> {
 
     writer.start()?;
     writer.write(DynIter::new(columns))?;
-    let writer = writer.end(None)?.1;
+    writer.end(None)?;
 
-    let data = writer.into_inner();
+    let data = writer.into_inner().into_inner();
     let mut reader = Cursor::new(data);
 
     let metadata = read_metadata(&mut reader)?;

--- a/tests/it/write/mod.rs
+++ b/tests/it/write/mod.rs
@@ -55,7 +55,6 @@ fn test_column(column: &str, compression: Compression) -> Result<()> {
 
     let options = WriteOptions {
         write_statistics: true,
-        compression,
         version: Version::V1,
     };
 
@@ -83,7 +82,7 @@ fn test_column(column: &str, compression: Compression) -> Result<()> {
             &options,
             &a[0].descriptor,
         ))),
-        options.compression,
+        compression,
         vec![],
     ));
     let columns = std::iter::once(Ok(pages));
@@ -187,7 +186,6 @@ fn basic() -> Result<()> {
 
     let options = WriteOptions {
         write_statistics: false,
-        compression: Compression::Uncompressed,
         version: Version::V1,
     };
 
@@ -205,7 +203,7 @@ fn basic() -> Result<()> {
             &options,
             &schema.columns()[0].descriptor,
         ))),
-        options.compression,
+        Compression::Uncompressed,
         vec![],
     ));
     let columns = std::iter::once(Ok(pages));
@@ -237,7 +235,6 @@ async fn test_column_async(column: &str) -> Result<()> {
 
     let options = WriteOptions {
         write_statistics: true,
-        compression: Compression::Uncompressed,
         version: Version::V1,
     };
 
@@ -264,7 +261,7 @@ async fn test_column_async(column: &str) -> Result<()> {
             &options,
             &a[0].descriptor,
         ))),
-        options.compression,
+        Compression::Uncompressed,
         vec![],
     ));
     let columns = std::iter::once(Ok(pages));

--- a/tests/it/write/mod.rs
+++ b/tests/it/write/mod.rs
@@ -203,7 +203,7 @@ fn basic() -> Result<()> {
             &options,
             &schema.columns()[0].descriptor,
         ))),
-        Compression::Uncompressed,
+        CompressionEncode::Uncompressed,
         vec![],
     ));
     let columns = std::iter::once(Ok(pages));
@@ -261,7 +261,7 @@ async fn test_column_async(column: &str) -> Result<()> {
             &options,
             &a[0].descriptor,
         ))),
-        Compression::Uncompressed,
+        CompressionEncode::Uncompressed,
         vec![],
     ));
     let columns = std::iter::once(Ok(pages));


### PR DESCRIPTION
Only adds zstd compression levels. Others can be added if the API is acceptable.