### PR TITLE
Fix minimum version for LZ4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ futures = { version = "0.3", optional = true }
 snap = { version = "^1.0", optional = true }
 brotli = { version = "^3.3", optional = true }
 flate2 = { version = "^1.0", optional = true }
-lz4 = { version = "1", optional = true }
+lz4 = { version = "1.23.3", optional = true }
 zstd = { version = "^0.11", optional = true, default-features = false }
 
 xxhash-rust = { version="0.8.3", optional = true, features = ["xxh64"] }


### PR DESCRIPTION
The `(de)compress_to_buffer` API we're using was only added in 1.23.3