### PR TITLE
Auto-detect page compression

### DIFF
--- a/src/page/mod.rs
+++ b/src/page/mod.rs
@@ -277,6 +277,13 @@ impl CompressedPage {
         }
     }
 
+    pub(crate) fn compression(&self) -> Compression {
+        match self {
+            CompressedPage::Data(page) => page.compression(),
+            CompressedPage::Dict(page) => page.compression(),
+        }
+    }
+
     pub(crate) fn num_values(&self) -> usize {
         match self {
             CompressedPage::Data(page) => page.num_values(),

--- a/src/page/page_dict/mod.rs
+++ b/src/page/page_dict/mod.rs
@@ -36,17 +36,24 @@ impl EncodedDictPage {
 #[derive(Debug)]
 pub struct CompressedDictPage {
     pub(crate) buffer: Vec<u8>,
+    compression: Compression,
     pub(crate) num_values: usize,
     pub(crate) uncompressed_page_size: usize,
 }
 
 impl CompressedDictPage {
-    pub fn new(buffer: Vec<u8>, uncompressed_page_size: usize, num_values: usize) -> Self {
+    pub fn new(buffer: Vec<u8>, compression: Compression, uncompressed_page_size: usize, num_values: usize) -> Self {
         Self {
             buffer,
+            compression,
             uncompressed_page_size,
             num_values,
         }
+    }
+
+    /// The compression of the data in this page.
+    pub fn compression(&self) -> Compression {
+        self.compression
     }
 }
 

--- a/src/write/compression.rs
+++ b/src/write/compression.rs
@@ -69,6 +69,7 @@ fn compress_dict(
     }
     Ok(CompressedDictPage::new(
         compressed_buffer,
+        compression,
         uncompressed_page_size,
         num_values,
     ))

--- a/src/write/file.rs
+++ b/src/write/file.rs
@@ -110,7 +110,6 @@ impl<W: Write> FileWriter<W> {
             &mut self.writer,
             self.offset,
             self.schema.columns(),
-            self.options.compression,
             row_group,
             ordinal,
         )?;

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -20,7 +20,6 @@ pub use file::FileWriter;
 
 pub use row_group::ColumnOffsetsMetadata;
 
-use crate::compression::Compression;
 use crate::page::CompressedPage;
 
 pub type RowGroupIter<'a, E> =
@@ -31,8 +30,6 @@ pub type RowGroupIter<'a, E> =
 pub struct WriteOptions {
     /// Whether to write statistics, including indexes
     pub write_statistics: bool,
-    /// Whether to use compression
-    pub compression: Compression,
     /// Which Parquet version to use
     pub version: Version,
 }

--- a/src/write/stream.rs
+++ b/src/write/stream.rs
@@ -106,7 +106,6 @@ impl<W: AsyncWrite + Unpin + Send> FileStreamer<W> {
             &mut self.writer,
             self.offset,
             self.schema.columns(),
-            self.options.compression,
             row_group,
         )
         .await?;

--- a/tests/it/write/indexes.rs
+++ b/tests/it/write/indexes.rs
@@ -25,7 +25,6 @@ fn write_file() -> Result<Vec<u8>> {
 
     let options = WriteOptions {
         write_statistics: true,
-        compression: Compression::Uncompressed,
         version: Version::V1,
     };
 
@@ -44,7 +43,7 @@ fn write_file() -> Result<Vec<u8>> {
 
     let pages = DynStreamingIterator::new(Compressor::new(
         DynIter::new(pages.into_iter()),
-        options.compression,
+        Compression::Uncompressed,
         vec![],
     ));
     let columns = std::iter::once(Ok(pages));

--- a/tests/it/write/mod.rs
+++ b/tests/it/write/mod.rs
@@ -55,7 +55,6 @@ fn test_column(column: &str, compression: Compression) -> Result<()> {
 
     let options = WriteOptions {
         write_statistics: true,
-        compression,
         version: Version::V1,
     };
 
@@ -83,7 +82,7 @@ fn test_column(column: &str, compression: Compression) -> Result<()> {
             &options,
             &a[0].descriptor,
         ))),
-        options.compression,
+        compression,
         vec![],
     ));
     let columns = std::iter::once(Ok(pages));
@@ -187,7 +186,6 @@ fn basic() -> Result<()> {
 
     let options = WriteOptions {
         write_statistics: false,
-        compression: Compression::Uncompressed,
         version: Version::V1,
     };
 
@@ -205,7 +203,7 @@ fn basic() -> Result<()> {
             &options,
             &schema.columns()[0].descriptor,
         ))),
-        options.compression,
+        Compression::Uncompressed,
         vec![],
     ));
     let columns = std::iter::once(Ok(pages));
@@ -237,7 +235,6 @@ async fn test_column_async(column: &str) -> Result<()> {
 
     let options = WriteOptions {
         write_statistics: true,
-        compression: Compression::Uncompressed,
         version: Version::V1,
     };
 
@@ -264,7 +261,7 @@ async fn test_column_async(column: &str) -> Result<()> {
             &options,
             &a[0].descriptor,
         ))),
-        options.compression,
+        Compression::Uncompressed,
         vec![],
     ));
     let columns = std::iter::once(Ok(pages));


### PR DESCRIPTION
This removes the explicit compression setting in `WriteOptions`.

It was somewhat confusing as the pages still needed to be appropriately
compressed, and limiting as it forced the same value for the whole file.

Let me know if I missed the motivation behind this field!