### PR TITLE
Deterministic encodings in metadata

### DIFF
--- a/src/write/column_chunk.rs
+++ b/src/write/column_chunk.rs
@@ -129,7 +129,7 @@ fn build_column_chunk(
             }
         })
         .sum();
-    let encodings = specs
+    let mut encodings = specs
         .iter()
         .flat_map(|spec| {
             let type_ = spec.header.type_.try_into().unwrap();
@@ -155,7 +155,10 @@ fn build_column_chunk(
         })
         .collect::<HashSet<_>>() // unique
         .into_iter() // to vec
-        .collect();
+        .collect::<Vec<_>>();
+
+    // Sort the encodings to have deterministic metadata
+    encodings.sort();
 
     let statistics = specs.iter().map(|x| &x.statistics).collect::<Vec<_>>();
     let statistics = reduce(&statistics)?;


### PR DESCRIPTION
Sort the encodings in column metadata as there's no defined order within
the `HashSet`.

I discovered this while comparing identical files at the byte level.