### PR TITLE
Made `.end` not consume the parquet `FileWriter`

### DIFF
--- a/src/write/file.rs
+++ b/src/write/file.rs
@@ -120,9 +120,8 @@ impl<W: Write> FileWriter<W> {
         Ok(())
     }
 
-    /// Writes the footer of the parquet file. Returns the total size of the file and the
-    /// underlying writer.
-    pub fn end(mut self, key_value_metadata: Option<Vec<KeyValue>>) -> Result<(u64, W)> {
+    /// Writes the footer of the parquet file. Returns the total size of the file.
+    pub fn end(&mut self, key_value_metadata: Option<Vec<KeyValue>>) -> Result<u64> {
         // compute file stats
         let num_rows = self.row_groups.iter().map(|group| group.num_rows).sum();
 
@@ -167,18 +166,23 @@ impl<W: Write> FileWriter<W> {
 
         let metadata = FileMetaData::new(
             self.options.version.into(),
-            self.schema.into_thrift(),
+            self.schema.clone().into_thrift(),
             num_rows,
-            self.row_groups,
+            self.row_groups.clone(),
             key_value_metadata,
-            self.created_by,
+            self.created_by.clone(),
             None,
             None,
             None,
         );
 
         let len = end_file(&mut self.writer, metadata)?;
-        Ok((self.offset + len, self.writer))
+        Ok(self.offset + len)
+    }
+
+    /// Returns the underlying writer.
+    pub fn into_inner(self) -> W {
+        self.writer
     }
 }
 

--- a/tests/it/write/indexes.rs
+++ b/tests/it/write/indexes.rs
@@ -54,9 +54,9 @@ fn write_file() -> Result<Vec<u8>> {
 
     writer.start()?;
     writer.write(DynIter::new(columns))?;
-    let writer = writer.end(None)?.1;
+    writer.end(None)?;
 
-    Ok(writer.into_inner())
+    Ok(writer.into_inner().into_inner())
 }
 
 #[test]

--- a/tests/it/write/mod.rs
+++ b/tests/it/write/mod.rs
@@ -93,9 +93,9 @@ fn test_column(column: &str, compression: Compression) -> Result<()> {
 
     writer.start()?;
     writer.write(DynIter::new(columns))?;
-    let writer = writer.end(None)?.1;
+    writer.end(None)?;
 
-    let data = writer.into_inner();
+    let data = writer.into_inner().into_inner();
 
     let (result, statistics) = read_column(&mut Cursor::new(data))?;
     assert_eq!(array, result);
@@ -215,9 +215,9 @@ fn basic() -> Result<()> {
 
     writer.start()?;
     writer.write(DynIter::new(columns))?;
-    let writer = writer.end(None)?.1;
+    writer.end(None)?;
 
-    let data = writer.into_inner();
+    let data = writer.into_inner().into_inner();
     let mut reader = Cursor::new(data);
 
     let metadata = read_metadata(&mut reader)?;


### PR DESCRIPTION
The user may want to finish the file without consuming the writer, i.e. the semantics of consuming the writer (memory management) should be independent of the semantics of ending the file (parquet specification)