### PR TITLE
Add CompressionOptions, which allows for zstd compression levels.

### DIFF
--- a/src/write/compression.rs
+++ b/src/write/compression.rs
@@ -1,6 +1,6 @@
+use crate::compression::CompressionOptions;
 use crate::error::{Error, Result};
 use crate::page::{CompressedDictPage, CompressedPage, DataPageHeader, EncodedDictPage};
-use crate::parquet_bridge::Compression;
 use crate::FallibleStreamingIterator;
 use crate::{
     compression,
@@ -11,7 +11,7 @@ use crate::{
 fn compress_data(
     page: DataPage,
     mut compressed_buffer: Vec<u8>,
-    compression: Compression,
+    compression: CompressionOptions,
 ) -> Result<CompressedDataPage> {
     let DataPage {
         mut buffer,
@@ -21,7 +21,7 @@ fn compress_data(
         selected_rows,
     } = page;
     let uncompressed_page_size = buffer.len();
-    if compression != Compression::Uncompressed {
+    if compression != CompressionOptions::Uncompressed {
         match &header {
             DataPageHeader::V1(_) => {
                 compression::compress(compression, &buffer, &mut compressed_buffer)?;
@@ -44,7 +44,7 @@ fn compress_data(
     Ok(CompressedDataPage::new_read(
         header,
         compressed_buffer,
-        compression,
+        compression.into(),
         uncompressed_page_size,
         dictionary_page,
         descriptor,
@@ -55,21 +55,21 @@ fn compress_data(
 fn compress_dict(
     page: EncodedDictPage,
     mut compressed_buffer: Vec<u8>,
-    compression: Compression,
+    compression: CompressionOptions,
 ) -> Result<CompressedDictPage> {
     let EncodedDictPage {
         mut buffer,
         num_values,
     } = page;
     let uncompressed_page_size = buffer.len();
-    if compression != Compression::Uncompressed {
+    if compression != CompressionOptions::Uncompressed {
         compression::compress(compression, &buffer, &mut compressed_buffer)?;
     } else {
         std::mem::swap(&mut buffer, &mut compressed_buffer);
     }
     Ok(CompressedDictPage::new(
         compressed_buffer,
-        compression,
+        compression.into(),
         uncompressed_page_size,
         num_values,
     ))
@@ -85,7 +85,7 @@ fn compress_dict(
 pub fn compress(
     page: EncodedPage,
     compressed_buffer: Vec<u8>,
-    compression: Compression,
+    compression: CompressionOptions,
 ) -> Result<CompressedPage> {
     match page {
         EncodedPage::Data(page) => {
@@ -101,19 +101,19 @@ pub fn compress(
 /// holding a reusable buffer ([`Vec<u8>`]) for compression.
 pub struct Compressor<I: Iterator<Item = Result<EncodedPage>>> {
     iter: I,
-    compression: Compression,
+    compression: CompressionOptions,
     buffer: Vec<u8>,
     current: Option<CompressedPage>,
 }
 
 impl<I: Iterator<Item = Result<EncodedPage>>> Compressor<I> {
     /// Creates a new [`Compressor`]
-    pub fn new_from_vec(iter: I, compression: Compression, buffer: Vec<u8>) -> Self {
+    pub fn new_from_vec(iter: I, compression: CompressionOptions, buffer: Vec<u8>) -> Self {
         Self::new(iter, compression, buffer)
     }
 
     /// Creates a new [`Compressor`]
-    pub fn new(iter: I, compression: Compression, buffer: Vec<u8>) -> Self {
+    pub fn new(iter: I, compression: CompressionOptions, buffer: Vec<u8>) -> Self {
         Self {
             iter,
             compression,

--- a/tests/it/write/indexes.rs
+++ b/tests/it/write/indexes.rs
@@ -1,6 +1,6 @@
 use std::io::Cursor;
 
-use parquet2::compression::Compression;
+use parquet2::compression::CompressionOptions;
 use parquet2::error::Result;
 use parquet2::indexes::{
     select_pages, BoundaryOrder, Index, Interval, NativeIndex, PageIndex, PageLocation,
@@ -43,7 +43,7 @@ fn write_file() -> Result<Vec<u8>> {
 
     let pages = DynStreamingIterator::new(Compressor::new(
         DynIter::new(pages.into_iter()),
-        Compression::Uncompressed,
+        CompressionOptions::Uncompressed,
         vec![],
     ));
     let columns = std::iter::once(Ok(pages));

--- a/tests/it/write/mod.rs
+++ b/tests/it/write/mod.rs
@@ -5,7 +5,7 @@ mod primitive;
 use std::io::{Cursor, Read, Seek};
 use std::sync::Arc;
 
-use parquet2::compression::Compression;
+use parquet2::compression::CompressionOptions;
 use parquet2::error::Result;
 use parquet2::metadata::SchemaDescriptor;
 use parquet2::read::read_metadata;
@@ -50,7 +50,7 @@ async fn read_column_async<
     Ok((a, statistics))
 }
 
-fn test_column(column: &str, compression: Compression) -> Result<()> {
+fn test_column(column: &str, compression: CompressionOptions) -> Result<()> {
     let array = alltypes_plain(column);
 
     let options = WriteOptions {
@@ -108,68 +108,68 @@ fn test_column(column: &str, compression: Compression) -> Result<()> {
 
 #[test]
 fn int32() -> Result<()> {
-    test_column("id", Compression::Uncompressed)
+    test_column("id", CompressionOptions::Uncompressed)
 }
 
 #[test]
 fn int32_snappy() -> Result<()> {
-    test_column("id", Compression::Snappy)
+    test_column("id", CompressionOptions::Snappy)
 }
 
 #[test]
 fn int32_lz4() -> Result<()> {
-    test_column("id", Compression::Lz4Raw)
+    test_column("id", CompressionOptions::Lz4Raw)
 }
 
 #[test]
 fn int32_lz4_short_i32_array() -> Result<()> {
-    test_column("id-short-array", Compression::Lz4Raw)
+    test_column("id-short-array", CompressionOptions::Lz4Raw)
 }
 
 #[test]
 fn int32_brotli() -> Result<()> {
-    test_column("id", Compression::Brotli)
+    test_column("id", CompressionOptions::Brotli)
 }
 
 #[test]
 #[ignore = "Native boolean writer not yet implemented"]
 fn bool() -> Result<()> {
-    test_column("bool_col", Compression::Uncompressed)
+    test_column("bool_col", CompressionOptions::Uncompressed)
 }
 
 #[test]
 fn tinyint() -> Result<()> {
-    test_column("tinyint_col", Compression::Uncompressed)
+    test_column("tinyint_col", CompressionOptions::Uncompressed)
 }
 
 #[test]
 fn smallint_col() -> Result<()> {
-    test_column("smallint_col", Compression::Uncompressed)
+    test_column("smallint_col", CompressionOptions::Uncompressed)
 }
 
 #[test]
 fn int_col() -> Result<()> {
-    test_column("int_col", Compression::Uncompressed)
+    test_column("int_col", CompressionOptions::Uncompressed)
 }
 
 #[test]
 fn bigint_col() -> Result<()> {
-    test_column("bigint_col", Compression::Uncompressed)
+    test_column("bigint_col", CompressionOptions::Uncompressed)
 }
 
 #[test]
 fn float_col() -> Result<()> {
-    test_column("float_col", Compression::Uncompressed)
+    test_column("float_col", CompressionOptions::Uncompressed)
 }
 
 #[test]
 fn double_col() -> Result<()> {
-    test_column("double_col", Compression::Uncompressed)
+    test_column("double_col", CompressionOptions::Uncompressed)
 }
 
 #[test]
 fn string_col() -> Result<()> {
-    test_column("string_col", Compression::Uncompressed)
+    test_column("string_col", CompressionOptions::Uncompressed)
 }
 
 #[test]
@@ -203,7 +203,7 @@ fn basic() -> Result<()> {
             &options,
             &schema.columns()[0].descriptor,
         ))),
-        Compression::Uncompressed,
+        CompressionOptions::Uncompressed,
         vec![],
     ));
     let columns = std::iter::once(Ok(pages));
@@ -261,7 +261,7 @@ async fn test_column_async(column: &str) -> Result<()> {
             &options,
             &a[0].descriptor,
         ))),
-        Compression::Uncompressed,
+        CompressionOptions::Uncompressed,
         vec![],
     ));
     let columns = std::iter::once(Ok(pages));


### PR DESCRIPTION
Following from the [previous draft request](https://github.com/jorgecarleitao/parquet2/pull/121) for optional `zstd` compression levels