### PR TITLE
Improved perf of bitpacking decoding (3.5x)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ xxhash-rust = { version="0.8.3", optional = true, features = ["xxh64"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt"] }
+criterion = "0.3"
 
 [features]
 default = ["snappy", "gzip", "lz4", "zstd", "brotli", "stream", "bloom_filter"]
@@ -37,3 +38,7 @@ snappy = ["snap"]
 gzip = ["flate2"]
 stream = ["futures", "async-stream"]
 bloom_filter = ["xxhash-rust"]
+
+[[bench]]
+name = "decode_bitpacking"
+harness = false

--- a/benches/decode_bitpacking.rs
+++ b/benches/decode_bitpacking.rs
@@ -1,0 +1,20 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+
+use parquet2::encoding::bitpacking::Decoder;
+
+fn add_benchmark(c: &mut Criterion) {
+    (10..=20).step_by(2).for_each(|log2_size| {
+        let size = 2usize.pow(log2_size);
+
+        let bytes = (0..size as u32)
+            .map(|x| 0b01011011u8.rotate_left(x))
+            .collect::<Vec<_>>();
+
+        c.bench_function(&format!("bitpacking 2^{}", log2_size), |b| {
+            b.iter(|| Decoder::new(&bytes, 1, size).count())
+        });
+    })
+}
+
+criterion_group!(benches, add_benchmark);
+criterion_main!(benches);

--- a/src/encoding/bitpacking.rs
+++ b/src/encoding/bitpacking.rs
@@ -93,6 +93,7 @@ impl<'a> Decoder<'a> {
 impl<'a> Iterator for Decoder<'a> {
     type Item = u32;
 
+    #[inline] // -71% improvement in bench
     fn next(&mut self) -> Option<Self::Item> {
         if self.remaining == 0 {
             return None;
@@ -109,6 +110,7 @@ impl<'a> Iterator for Decoder<'a> {
         Some(result)
     }
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         (self.remaining, Some(self.remaining))
     }


### PR DESCRIPTION
Inlining `next` yields a major improvement