### PR TITLE
Improved performance of RLE decoding (-18%)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,7 @@ bloom_filter = ["xxhash-rust"]
 [[bench]]
 name = "decode_bitpacking"
 harness = false
+
+[[bench]]
+name = "decode_rle"
+harness = false

--- a/benches/decode_rle.rs
+++ b/benches/decode_rle.rs
@@ -1,0 +1,19 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+
+use parquet2::encoding::hybrid_rle::{encode_u32, Decoder};
+
+fn add_benchmark(c: &mut Criterion) {
+    (10..=20).step_by(2).for_each(|log2_size| {
+        let size = 2usize.pow(log2_size);
+
+        let mut bytes = vec![];
+        encode_u32(&mut bytes, (0..size as u32).map(|x| x % 128), 8).unwrap();
+
+        c.bench_function(&format!("rle decode 2^{}", log2_size), |b| {
+            b.iter(|| Decoder::new(&bytes, 1).count())
+        });
+    })
+}
+
+criterion_group!(benches, add_benchmark);
+criterion_main!(benches);

--- a/src/encoding/hybrid_rle/decoder.rs
+++ b/src/encoding/hybrid_rle/decoder.rs
@@ -23,6 +23,7 @@ impl<'a> Decoder<'a> {
 impl<'a> Iterator for Decoder<'a> {
     type Item = HybridEncoded<'a>;
 
+    #[inline] // -18% improvement in bench
     fn next(&mut self) -> Option<Self::Item> {
         if self.values.is_empty() {
             return None;


### PR DESCRIPTION
Same idea as #129 - inlining `next` has performance implications