### PR TITLE
Fix potential misuse of FileWriter API's (sync + async)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub mod write;
 pub use streaming_decompression::fallible_streaming_iterator;
 pub use streaming_decompression::FallibleStreamingIterator;
 
+const HEADER_SIZE: u64 = PARQUET_MAGIC.len() as u64;
 const FOOTER_SIZE: u64 = 8;
 const PARQUET_MAGIC: [u8; 4] = [b'P', b'A', b'R', b'1'];
 

--- a/src/read/metadata.rs
+++ b/src/read/metadata.rs
@@ -10,6 +10,7 @@ use parquet_format_async_temp::FileMetaData as TFileMetaData;
 use super::super::{metadata::FileMetaData, DEFAULT_FOOTER_READ_SIZE, FOOTER_SIZE, PARQUET_MAGIC};
 
 use crate::error::{Error, Result};
+use crate::HEADER_SIZE;
 
 pub(super) fn metadata_len(buffer: &[u8], len: usize) -> i32 {
     i32::from_le_bytes(buffer[len - 8..len - 4].try_into().unwrap())
@@ -41,9 +42,9 @@ fn stream_len(seek: &mut impl Seek) -> std::result::Result<u64, std::io::Error> 
 pub fn read_metadata<R: Read + Seek>(reader: &mut R) -> Result<FileMetaData> {
     // check file is large enough to hold footer
     let file_size = stream_len(reader)?;
-    if file_size < FOOTER_SIZE {
+    if file_size < HEADER_SIZE + FOOTER_SIZE {
         return Err(general_err!(
-            "Invalid Parquet file. Size is smaller than footer"
+            "Invalid Parquet file. Size is smaller than header + footer"
         ));
     }
 

--- a/src/read/stream.rs
+++ b/src/read/stream.rs
@@ -7,6 +7,7 @@ use parquet_format_async_temp::FileMetaData as TFileMetaData;
 use super::super::{metadata::FileMetaData, DEFAULT_FOOTER_READ_SIZE, FOOTER_SIZE, PARQUET_MAGIC};
 use super::metadata::metadata_len;
 use crate::error::{Error, Result};
+use crate::HEADER_SIZE;
 
 async fn stream_len(
     seek: &mut (impl AsyncSeek + std::marker::Unpin),
@@ -30,7 +31,7 @@ pub async fn read_metadata<R: AsyncRead + AsyncSeek + Send + std::marker::Unpin>
     let file_size = stream_len(reader).await?;
 
     // check file is large enough to hold footer
-    if file_size < FOOTER_SIZE {
+    if file_size < HEADER_SIZE + FOOTER_SIZE {
         return Err(general_err!(
             "Invalid Parquet file. Size is smaller than footer"
         ));

--- a/src/write/file.rs
+++ b/src/write/file.rs
@@ -128,7 +128,7 @@ impl<W: Write> FileWriter<W> {
 
     /// Writes the footer of the parquet file. Returns the total size of the file and the
     /// underlying writer.
-    pub fn end(mut self, key_value_metadata: Option<Vec<KeyValue>>) -> Result<(u64, W)> {
+    pub fn end(&mut self, key_value_metadata: Option<Vec<KeyValue>>) -> Result<u64> {
         if self.offset == 0 {
             self.start()?;
         }
@@ -188,7 +188,7 @@ impl<W: Write> FileWriter<W> {
         );
 
         let len = end_file(&mut self.writer, metadata)?;
-        Ok((self.offset + len, self.writer))
+        Ok(self.offset + len)
     }
 
     /// Returns the underlying writer.

--- a/src/write/file.rs
+++ b/src/write/file.rs
@@ -139,7 +139,7 @@ impl<W: Write> FileWriter<W> {
         }
 
         if self.state != State::Started {
-            Err(Error::General("End cannot be called twice".to_string()))
+            return Err(Error::General("End cannot be called twice".to_string()));
         }
         // compute file stats
         let num_rows = self.row_groups.iter().map(|group| group.num_rows).sum();

--- a/src/write/file.rs
+++ b/src/write/file.rs
@@ -86,10 +86,19 @@ impl<W: Write> FileWriter<W> {
         }
     }
 
-    /// Writes the header of the file
-    pub fn start(&mut self) -> Result<()> {
-        self.offset = start_file(&mut self.writer)? as u64;
-        Ok(())
+    /// Writes the header of the file.
+    ///
+    /// This is automatically called by [`Self::write`] if not called following [`Self::new`].
+    ///
+    /// # Errors
+    /// Returns an error if data has been written to the file.
+    fn start(&mut self) -> Result<()> {
+        if self.offset == 0 {
+            self.offset = start_file(&mut self.writer)? as u64;
+            Ok(())
+        } else {
+            Err(Error::General("Start cannot be called twice".to_string()))
+        }
     }
 
     /// Writes a row group to the file.
@@ -101,9 +110,7 @@ impl<W: Write> FileWriter<W> {
         E: std::error::Error,
     {
         if self.offset == 0 {
-            return Err(Error::General(
-                "You must call `start` before writing the first row group".to_string(),
-            ));
+            self.start()?;
         }
         let ordinal = self.row_groups.len();
         let (group, specs, size) = write_row_group(
@@ -119,8 +126,13 @@ impl<W: Write> FileWriter<W> {
         Ok(())
     }
 
-    /// Writes the footer of the parquet file. Returns the total size of the file.
-    pub fn end(&mut self, key_value_metadata: Option<Vec<KeyValue>>) -> Result<u64> {
+    /// Writes the footer of the parquet file. Returns the total size of the file and the
+    /// underlying writer.
+    pub fn end(mut self, key_value_metadata: Option<Vec<KeyValue>>) -> Result<(u64, W)> {
+        if self.offset == 0 {
+            self.start()?;
+        }
+
         // compute file stats
         let num_rows = self.row_groups.iter().map(|group| group.num_rows).sum();
 
@@ -176,7 +188,7 @@ impl<W: Write> FileWriter<W> {
         );
 
         let len = end_file(&mut self.writer, metadata)?;
-        Ok(self.offset + len)
+        Ok((self.offset + len, self.writer))
     }
 
     /// Returns the underlying writer.

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -41,6 +41,14 @@ pub enum Version {
     V2,
 }
 
+/// Used to recall the state of the parquet writer - whether sync or async.
+#[derive(PartialEq)]
+enum State {
+    Initialised,
+    Started,
+    Finished,
+}
+
 impl From<Version> for i32 {
     fn from(version: Version) -> Self {
         match version {

--- a/src/write/stream.rs
+++ b/src/write/stream.rs
@@ -134,7 +134,7 @@ impl<W: AsyncWrite + Unpin + Send> FileStreamer<W> {
         }
 
         if self.state != State::Started {
-            Err(Error::General("End cannot be called twice".to_string()))
+            return Err(Error::General("End cannot be called twice".to_string()));
         }
         // compute file stats
         let num_rows = self.row_groups.iter().map(|group| group.num_rows).sum();

--- a/tests/it/write/indexes.rs
+++ b/tests/it/write/indexes.rs
@@ -51,11 +51,10 @@ fn write_file() -> Result<Vec<u8>> {
     let writer = Cursor::new(vec![]);
     let mut writer = FileWriter::new(writer, schema, options, None);
 
-    writer.start()?;
     writer.write(DynIter::new(columns))?;
-    writer.end(None)?;
+    let (_, writer) = writer.end(None)?;
 
-    Ok(writer.into_inner().into_inner())
+    Ok(writer.into_inner())
 }
 
 #[test]

--- a/tests/it/write/indexes.rs
+++ b/tests/it/write/indexes.rs
@@ -52,9 +52,9 @@ fn write_file() -> Result<Vec<u8>> {
     let mut writer = FileWriter::new(writer, schema, options, None);
 
     writer.write(DynIter::new(columns))?;
-    let (_, writer) = writer.end(None)?;
+    writer.end(None)?;
 
-    Ok(writer.into_inner())
+    Ok(writer.into_inner().into_inner())
 }
 
 #[test]

--- a/tests/it/write/mod.rs
+++ b/tests/it/write/mod.rs
@@ -91,9 +91,9 @@ fn test_column(column: &str, compression: CompressionOptions) -> Result<()> {
     let mut writer = FileWriter::new(writer, schema, options, None);
 
     writer.write(DynIter::new(columns))?;
-    let (_, writer) = writer.end(None)?;
+    writer.end(None)?;
 
-    let data = writer.into_inner();
+    let data = writer.into_inner().into_inner();
 
     let (result, statistics) = read_column(&mut Cursor::new(data))?;
     assert_eq!(array, result);
@@ -214,9 +214,9 @@ fn basic() -> Result<()> {
     let mut writer = FileWriter::new(writer, schema, options, None);
 
     writer.write(DynIter::new(columns))?;
-    let (_, writer) = writer.end(None)?;
+    writer.end(None)?;
 
-    let data = writer.into_inner();
+    let data = writer.into_inner().into_inner();
     let mut reader = Cursor::new(data);
 
     let metadata = read_metadata(&mut reader)?;
@@ -271,9 +271,9 @@ async fn test_column_async(column: &str) -> Result<()> {
     let mut writer = FileStreamer::new(writer, schema, options, None);
 
     writer.write(DynIter::new(columns)).await?;
-    let writer = writer.end(None).await?.1;
+    writer.end(None).await?;
 
-    let data = writer.into_inner();
+    let data = writer.into_inner().into_inner();
 
     let (result, statistics) = read_column_async(&mut futures::io::Cursor::new(data)).await?;
     assert_eq!(array, result);

--- a/tests/it/write/mod.rs
+++ b/tests/it/write/mod.rs
@@ -90,11 +90,10 @@ fn test_column(column: &str, compression: CompressionOptions) -> Result<()> {
     let writer = Cursor::new(vec![]);
     let mut writer = FileWriter::new(writer, schema, options, None);
 
-    writer.start()?;
     writer.write(DynIter::new(columns))?;
-    writer.end(None)?;
+    let (_, writer) = writer.end(None)?;
 
-    let data = writer.into_inner().into_inner();
+    let data = writer.into_inner();
 
     let (result, statistics) = read_column(&mut Cursor::new(data))?;
     assert_eq!(array, result);
@@ -214,11 +213,10 @@ fn basic() -> Result<()> {
     let writer = Cursor::new(vec![]);
     let mut writer = FileWriter::new(writer, schema, options, None);
 
-    writer.start()?;
     writer.write(DynIter::new(columns))?;
-    writer.end(None)?;
+    let (_, writer) = writer.end(None)?;
 
-    let data = writer.into_inner().into_inner();
+    let data = writer.into_inner();
     let mut reader = Cursor::new(data);
 
     let metadata = read_metadata(&mut reader)?;
@@ -272,7 +270,6 @@ async fn test_column_async(column: &str) -> Result<()> {
     let writer = futures::io::Cursor::new(vec![]);
     let mut writer = FileStreamer::new(writer, schema, options, None);
 
-    writer.start().await?;
     writer.write(DynIter::new(columns)).await?;
     let writer = writer.end(None).await?.1;
 


### PR DESCRIPTION
* It was possible to call start multiple times, which would lead to `FileWriter.offset` to be out of sync with the file.
* `FileWriter::start` can no longer be called, and runtime errors are not returned by `FileWriter.write`.
* Synchronises async and sync api's for `FileWriter.end`. Sync can no longer write the footer twice.
* Reading parquet files didn't check the file size included the header

This is a breaking change