### PR TITLE
Removed unused cargo feature

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Run
         run: cargo test
       - name: Run lz4-flex
-        run: cargo test --no-default-features --features lz4_flex,bloom_filter,stream,snappy,brotli,zstd,gzip
+        run: cargo test --no-default-features --features lz4_flex,bloom_filter,snappy,brotli,zstd,gzip
 
   clippy:
     name: Clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ parquet-format-async-temp = "0.3.0"
 bitpacking = { version = "0.8.2", default-features = false, features = ["bitpacker1x"] }
 streaming-decompression = "0.1"
 
-async-stream = { version = "0.3.2", optional = true }
-futures = { version = "0.3", optional = true }
+async-stream = { version = "0.3.2" }
+futures = { version = "0.3" }
 
 snap = { version = "^1.0", optional = true }
 brotli = { version = "^3.3", optional = true }
@@ -36,10 +36,9 @@ tokio = { version = "1", features = ["macros", "rt"] }
 criterion = "0.3"
 
 [features]
-default = ["snappy", "gzip", "lz4", "zstd", "brotli", "stream", "bloom_filter"]
+default = ["snappy", "gzip", "lz4", "zstd", "brotli", "bloom_filter"]
 snappy = ["snap"]
 gzip = ["flate2"]
-stream = ["futures", "async-stream"]
 bloom_filter = ["xxhash-rust"]
 
 [[bench]]

--- a/src/encoding/delta_bitpacked/decoder.rs
+++ b/src/encoding/delta_bitpacked/decoder.rs
@@ -8,7 +8,7 @@ use super::super::zigzag_leb128;
 struct Block<'a> {
     // this is the minimum delta that must be added to every value.
     min_delta: i64,
-    num_mini_blocks: usize,
+    _num_mini_blocks: usize,
     values_per_mini_block: usize,
     bitwidths: &'a [u8],
     values: &'a [u8],
@@ -40,7 +40,7 @@ impl<'a> Block<'a> {
 
         let mut block = Block {
             min_delta,
-            num_mini_blocks,
+            _num_mini_blocks: num_mini_blocks,
             values_per_mini_block,
             bitwidths,
             remaining: length,

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -3,7 +3,6 @@ mod indexes;
 pub mod levels;
 mod metadata;
 mod page;
-#[cfg(feature = "stream")]
 mod stream;
 
 use std::io::{Read, Seek, SeekFrom};
@@ -12,10 +11,8 @@ use std::vec::IntoIter;
 
 pub use compression::{decompress, BasicDecompressor, Decompressor};
 pub use metadata::read_metadata;
-#[cfg(feature = "stream")]
 pub use page::get_page_stream;
 pub use page::{IndexedPageReader, PageFilter, PageIterator, PageMetaData, PageReader};
-#[cfg(feature = "stream")]
 pub use stream::read_metadata as read_metadata_async;
 
 use crate::error::Error;

--- a/src/read/page/mod.rs
+++ b/src/read/page/mod.rs
@@ -1,6 +1,5 @@
 mod indexed_reader;
 mod reader;
-#[cfg(feature = "stream")]
 mod stream;
 
 use crate::{error::Error, page::CompressedDataPage};
@@ -12,5 +11,4 @@ pub trait PageIterator: Iterator<Item = Result<CompressedDataPage, Error>> {
     fn swap_buffer(&mut self, buffer: &mut Vec<u8>);
 }
 
-#[cfg(feature = "stream")]
 pub use stream::get_page_stream;

--- a/src/write/mod.rs
+++ b/src/write/mod.rs
@@ -6,9 +6,7 @@ pub(crate) mod page;
 mod row_group;
 pub(self) mod statistics;
 
-#[cfg(feature = "stream")]
 mod stream;
-#[cfg(feature = "stream")]
 pub use stream::FileStreamer;
 
 mod dyn_iter;

--- a/src/write/page.rs
+++ b/src/write/page.rs
@@ -225,12 +225,8 @@ mod tests {
 
     #[test]
     fn dict_too_many_values() {
-        let page = CompressedDictPage::new(
-            vec![],
-            Compression::Uncompressed,
-            0,
-            i32::MAX as usize + 1,
-        );
+        let page =
+            CompressedDictPage::new(vec![], Compression::Uncompressed, 0, i32::MAX as usize + 1);
         assert!(assemble_dict_page_header(&page).is_err());
     }
 }

--- a/tests/it/read/primitive.rs
+++ b/tests/it/read/primitive.rs
@@ -26,6 +26,7 @@ where
 
 /// The deserialization state of a `DataPage` of `Primitive` parquet primitive type
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum PageState<'a, T>
 where
     T: NativeType,


### PR DESCRIPTION
They are required by thrift and the crate does not compile without it, so we may as well make it required for simplicity