### PR TITLE
Removed `AsyncSeek` requirement from page stream

### DIFF
--- a/src/page/page_dict/mod.rs
+++ b/src/page/page_dict/mod.rs
@@ -42,7 +42,12 @@ pub struct CompressedDictPage {
 }
 
 impl CompressedDictPage {
-    pub fn new(buffer: Vec<u8>, compression: Compression, uncompressed_page_size: usize, num_values: usize) -> Self {
+    pub fn new(
+        buffer: Vec<u8>,
+        compression: Compression,
+        uncompressed_page_size: usize,
+        num_values: usize,
+    ) -> Self {
         Self {
             buffer,
             compression,

--- a/src/read/metadata.rs
+++ b/src/read/metadata.rs
@@ -93,9 +93,13 @@ pub fn read_metadata<R: Read + Seek>(reader: &mut R) -> Result<FileMetaData> {
         Cursor::new(buffer)
     };
 
+    deserialize_metadata(reader)
+}
+
+/// Parse loaded metadata bytes
+pub fn deserialize_metadata<R: Read>(reader: R) -> Result<FileMetaData> {
     let mut prot = TCompactInputProtocol::new(reader);
-    let metadata = TFileMetaData::read_from_in_protocol(&mut prot)
-        .map_err(|e| Error::General(format!("Could not parse metadata: {}", e)))?;
+    let metadata = TFileMetaData::read_from_in_protocol(&mut prot)?;
 
     FileMetaData::try_from_thrift(metadata)
 }

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use std::vec::IntoIter;
 
 pub use compression::{decompress, BasicDecompressor, Decompressor};
-pub use metadata::read_metadata;
+pub use metadata::{deserialize_metadata, read_metadata};
 pub use page::{get_page_stream, get_page_stream_from_column_start};
 pub use page::{IndexedPageReader, PageFilter, PageIterator, PageMetaData, PageReader};
 pub use stream::read_metadata as read_metadata_async;

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -11,7 +11,7 @@ use std::vec::IntoIter;
 
 pub use compression::{decompress, BasicDecompressor, Decompressor};
 pub use metadata::read_metadata;
-pub use page::get_page_stream;
+pub use page::{get_page_stream, get_page_stream_from_column_start};
 pub use page::{IndexedPageReader, PageFilter, PageIterator, PageMetaData, PageReader};
 pub use stream::read_metadata as read_metadata_async;
 

--- a/src/read/page/mod.rs
+++ b/src/read/page/mod.rs
@@ -12,3 +12,4 @@ pub trait PageIterator: Iterator<Item = Result<CompressedDataPage, Error>> {
 }
 
 pub use stream::get_page_stream;
+pub use stream::get_page_stream_from_column_start;

--- a/src/read/stream.rs
+++ b/src/read/stream.rs
@@ -1,11 +1,9 @@
 use std::io::{Cursor, Seek, SeekFrom};
 
 use futures::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt};
-use parquet_format_async_temp::thrift::protocol::TCompactInputProtocol;
-use parquet_format_async_temp::FileMetaData as TFileMetaData;
 
 use super::super::{metadata::FileMetaData, DEFAULT_FOOTER_READ_SIZE, FOOTER_SIZE, PARQUET_MAGIC};
-use super::metadata::metadata_len;
+use super::metadata::{deserialize_metadata, metadata_len};
 use crate::error::{Error, Result};
 use crate::HEADER_SIZE;
 
@@ -85,8 +83,5 @@ pub async fn read_metadata<R: AsyncRead + AsyncSeek + Send + std::marker::Unpin>
         Cursor::new(buffer)
     };
 
-    let mut prot = TCompactInputProtocol::new(reader);
-    let metadata = TFileMetaData::read_from_in_protocol(&mut prot)?;
-
-    FileMetaData::try_from_thrift(metadata)
+    deserialize_metadata(reader)
 }


### PR DESCRIPTION
When streaming pages over the network it is quite awkward to fulfill the `AsyncSeek` constraint.

This PR exposes methods that work nicely with usages that only provide `AsyncRead` (for example, a [Rusoto S3 `StreamingBody`](https://rusoto.github.io/rusoto/rusoto_s3/struct.GetObjectOutput.html#structfield.body) /w `TryStreamExt::into_async_read`).

`cargo test` passes, but I note there are no tests that exercise the page filtering. A naive attempt to add additional pages in `test_column_async` didn't work. If the lack of tests here are of concern then I need some guidance on where/how to add them.