### PR TITLE
Removed panics on read

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ name = "parquet2"
 bench = false
 
 [dependencies]
-parquet-format-async-temp = "0.3.0"
+parquet-format-async-temp = "0.3.1"
 bitpacking = { version = "0.8.2", default-features = false, features = ["bitpacker1x"] }
 streaming-decompression = "0.1"
 
@@ -34,6 +34,7 @@ xxhash-rust = { version="0.8.3", optional = true, features = ["xxh64"] }
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt"] }
 criterion = "0.3"
+rand = "0.8"
 
 [features]
 default = ["snappy", "gzip", "lz4", "zstd", "brotli", "bloom_filter"]

--- a/examples/read_metadata.rs
+++ b/examples/read_metadata.rs
@@ -6,9 +6,9 @@ use parquet2::encoding::Encoding;
 use parquet2::page::{split_buffer, DataPage};
 use parquet2::schema::types::PhysicalType;
 
-fn deserialize(page: &DataPage) {
+fn deserialize(page: &DataPage) -> Result<()> {
     // split the data buffer in repetition levels, definition levels and values
-    let (_rep_levels, _def_levels, _values_buffer) = split_buffer(page);
+    let (_rep_levels, _def_levels, _values_buffer) = split_buffer(page)?;
 
     // decode and deserialize.
     match (

--- a/src/deserialize/boolean.rs
+++ b/src/deserialize/boolean.rs
@@ -22,15 +22,15 @@ impl<'a> BooleanPageState<'a> {
 
         match (page.encoding(), page.dictionary_page(), is_optional) {
             (Encoding::Plain, _, true) => {
-                let validity = utils::DefLevelsDecoder::new(page);
+                let validity = utils::DefLevelsDecoder::try_new(page)?;
 
-                let (_, _, values) = split_buffer(page);
+                let (_, _, values) = split_buffer(page)?;
                 let values = BitmapIter::new(values, 0, values.len() * 8);
 
                 Ok(Self::Optional(validity, values))
             }
             (Encoding::Plain, _, false) => {
-                let (_, _, values) = split_buffer(page);
+                let (_, _, values) = split_buffer(page)?;
                 Ok(Self::Required(values, page.num_values()))
             }
             _ => Err(Error::General(format!(

--- a/src/deserialize/fixed_len.rs
+++ b/src/deserialize/fixed_len.rs
@@ -41,10 +41,10 @@ pub struct Dictionary<'a> {
 }
 
 impl<'a> Dictionary<'a> {
-    pub fn new(page: &'a DataPage, dict: &'a FixedLenByteArrayPageDict) -> Self {
-        let indexes = utils::dict_indices_decoder(page);
+    pub fn try_new(page: &'a DataPage, dict: &'a FixedLenByteArrayPageDict) -> Result<Self, Error> {
+        let indexes = utils::dict_indices_decoder(page)?;
 
-        Self { indexes, dict }
+        Ok(Self { indexes, dict })
     }
 
     #[inline]
@@ -79,26 +79,26 @@ impl<'a> FixedLenBinaryPageState<'a> {
         match (page.encoding(), page.dictionary_page(), is_optional) {
             (Encoding::PlainDictionary | Encoding::RleDictionary, Some(dict), false) => {
                 let dict = dict.as_any().downcast_ref().unwrap();
-                Ok(Self::RequiredDictionary(Dictionary::new(page, dict)))
+                Ok(Self::RequiredDictionary(Dictionary::try_new(page, dict)?))
             }
             (Encoding::PlainDictionary | Encoding::RleDictionary, Some(dict), true) => {
                 let dict = dict.as_any().downcast_ref().unwrap();
 
                 Ok(Self::OptionalDictionary(
-                    utils::DefLevelsDecoder::new(page),
-                    Dictionary::new(page, dict),
+                    utils::DefLevelsDecoder::try_new(page)?,
+                    Dictionary::try_new(page, dict)?,
                 ))
             }
             (Encoding::Plain, _, true) => {
-                let (_, _, values) = split_buffer(page);
+                let (_, _, values) = split_buffer(page)?;
 
-                let validity = utils::DefLevelsDecoder::new(page);
+                let validity = utils::DefLevelsDecoder::try_new(page)?;
                 let values = FixexBinaryIter::new(values, size);
 
                 Ok(Self::Optional(validity, values))
             }
             (Encoding::Plain, _, false) => {
-                let (_, _, values) = split_buffer(page);
+                let (_, _, values) = split_buffer(page)?;
                 let values = FixexBinaryIter::new(values, size);
 
                 Ok(Self::Required(values))

--- a/src/encoding/bitpacking.rs
+++ b/src/encoding/bitpacking.rs
@@ -69,16 +69,16 @@ fn decode_pack(compressed: &[u8], num_bits: u8, pack: &mut [u32; BitPacker1x::BL
 }
 
 impl<'a> Decoder<'a> {
-    pub fn new(compressed: &'a [u8], num_bits: u8, length: usize) -> Self {
+    pub fn new(compressed: &'a [u8], num_bits: u8, mut length: usize) -> Self {
         let compressed_block_size = BitPacker1x::BLOCK_LEN * num_bits as usize / 8;
 
         let mut compressed_chunks = compressed.chunks(compressed_block_size);
         let mut current_pack = [0; BitPacker1x::BLOCK_LEN];
-        decode_pack(
-            compressed_chunks.next().unwrap(),
-            num_bits,
-            &mut current_pack,
-        );
+        if let Some(chunk) = compressed_chunks.next() {
+            decode_pack(chunk, num_bits, &mut current_pack);
+        } else {
+            length = 0
+        };
 
         Self {
             remaining: length,

--- a/src/encoding/mod.rs
+++ b/src/encoding/mod.rs
@@ -14,8 +14,10 @@ pub use crate::parquet_bridge::Encoding;
 /// # Panics
 /// This function panics iff `values.len() < 4`.
 #[inline]
-pub fn get_length(values: &[u8]) -> u32 {
-    u32::from_le_bytes(values[0..4].try_into().unwrap())
+pub fn get_length(values: &[u8]) -> Option<usize> {
+    values
+        .get(0..4)
+        .map(|x| u32::from_le_bytes(x.try_into().unwrap()) as usize)
 }
 
 /// Returns the ceil of value/divisor

--- a/src/encoding/plain_byte_array.rs
+++ b/src/encoding/plain_byte_array.rs
@@ -29,8 +29,13 @@ impl<'a> Iterator for BinaryIter<'a> {
         }
         let length = u32::from_le_bytes(self.values[0..4].try_into().unwrap()) as usize;
         self.values = &self.values[4..];
-        let result = &self.values[..length];
-        self.values = &self.values[length..];
+        if length > self.values.len() {
+            return Some(Err(Error::OutOfSpec(
+                "A string in plain encoding declares a length that is out of range".to_string(),
+            )));
+        }
+        let (result, remaining) = self.values.split_at(length);
+        self.values = remaining;
         Some(Ok(result))
     }
 

--- a/src/encoding/plain_byte_array.rs
+++ b/src/encoding/plain_byte_array.rs
@@ -2,6 +2,7 @@
 /// prefixes, lengths and values
 /// # Implementation
 /// This struct does not allocate on the heap.
+use crate::error::Error;
 
 #[derive(Debug)]
 pub struct BinaryIter<'a> {
@@ -16,7 +17,7 @@ impl<'a> BinaryIter<'a> {
 }
 
 impl<'a> Iterator for BinaryIter<'a> {
-    type Item = &'a [u8];
+    type Item = Result<&'a [u8], Error>;
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
@@ -30,7 +31,7 @@ impl<'a> Iterator for BinaryIter<'a> {
         self.values = &self.values[4..];
         let result = &self.values[..length];
         self.values = &self.values[length..];
-        Some(result)
+        Some(Ok(result))
     }
 
     #[inline]

--- a/src/metadata/file_metadata.rs
+++ b/src/metadata/file_metadata.rs
@@ -40,7 +40,7 @@ pub struct FileMetaData {
 }
 
 impl FileMetaData {
-    /// Returns the ['SchemaDescriptor`] that describes schema of this file.
+    /// Returns the [`SchemaDescriptor`] that describes schema of this file.
     pub fn schema(&self) -> &SchemaDescriptor {
         &self.schema_descr
     }
@@ -69,7 +69,7 @@ impl FileMetaData {
             .row_groups
             .into_iter()
             .map(|rg| RowGroupMetaData::try_from_thrift(&schema_descr, rg))
-            .collect::<Result<Vec<_>, Error>>()?;
+            .collect::<Result<_, Error>>()?;
 
         let column_orders = metadata
             .column_orders

--- a/src/page/page_dict/fixed_len_binary.rs
+++ b/src/page/page_dict/fixed_len_binary.rs
@@ -1,6 +1,6 @@
 use std::{any::Any, sync::Arc};
 
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::schema::types::PhysicalType;
 
 use super::DictPage;
@@ -30,8 +30,14 @@ impl FixedLenByteArrayPageDict {
     }
 
     #[inline]
-    pub fn value(&self, index: usize) -> &[u8] {
-        &self.values[index * self.size..(index + 1) * self.size]
+    pub fn value(&self, index: usize) -> Result<&[u8]> {
+        self.values
+            .get(index * self.size..(index + 1) * self.size)
+            .ok_or_else(|| {
+                Error::OutOfSpec(
+                    "The data page has an index larger than the dictionary page values".to_string(),
+                )
+            })
     }
 }
 

--- a/src/read/page/stream.rs
+++ b/src/read/page/stream.rs
@@ -56,7 +56,7 @@ fn _get_page_stream<R: AsyncRead + AsyncSeek + Unpin + Send>(
             // the header
             let page_header = read_page_header(reader).await?;
 
-            let data_header = get_page_header(&page_header);
+            let data_header = get_page_header(&page_header)?;
             seen_values += data_header.as_ref().map(|x| x.num_values() as i64).unwrap_or_default();
 
             let read_size = page_header.compressed_page_size as i64;

--- a/src/schema/io_thrift/from_thrift.rs
+++ b/src/schema/io_thrift/from_thrift.rs
@@ -37,7 +37,9 @@ fn from_thrift_helper(elements: &[SchemaElement], index: usize) -> Result<(usize
     // There is only one message type node in the schema tree.
     let is_root_node = index == 0;
 
-    let element = &elements[index];
+    let element = elements.get(index).ok_or_else(|| {
+        Error::OutOfSpec(format!("index {} on SchemaElement is not valid", index))
+    })?;
     let name = element.name.clone();
     let converted_type = element.converted_type;
 
@@ -55,8 +57,7 @@ fn from_thrift_helper(elements: &[SchemaElement], index: usize) -> Result<(usize
                 .ok_or_else(|| {
                     general_err!("Repetition level must be defined for a primitive type")
                 })?
-                .try_into()
-                .unwrap();
+                .try_into()?;
             let physical_type = element.type_.ok_or_else(|| {
                 general_err!("Physical type must be defined for a primitive type")
             })?;

--- a/tests/it/read/binary.rs
+++ b/tests/it/read/binary.rs
@@ -9,9 +9,13 @@ pub fn page_to_vec(page: &DataPage) -> Result<Vec<Option<Vec<u8>>>> {
 
     match state {
         BinaryPageState::Optional(validity, values) => {
-            deserialize_optional(validity, values.map(|x| x.to_vec()))
+            deserialize_optional(validity, values.map(|x| x.map(|x| x.to_vec())))
         }
-        BinaryPageState::Required(values) => Ok(values.map(|x| x.to_vec()).map(Some).collect()),
+        BinaryPageState::Required(values) => values
+            .map(|x| x.map(|x| x.to_vec()))
+            .map(Some)
+            .map(|x| x.transpose())
+            .collect(),
         BinaryPageState::RequiredDictionary(dict) => dict
             .indexes
             .map(|x| x as usize)
@@ -21,7 +25,7 @@ pub fn page_to_vec(page: &DataPage) -> Result<Vec<Option<Vec<u8>>>> {
             let values = dict
                 .indexes
                 .map(|x| x as usize)
-                .map(|x| dict.dict.value(x).map(|x| x.to_vec()).unwrap());
+                .map(|x| dict.dict.value(x).map(|x| x.to_vec()));
             deserialize_optional(validity, values)
         }
     }

--- a/tests/it/read/boolean.rs
+++ b/tests/it/read/boolean.rs
@@ -10,7 +10,9 @@ pub fn page_to_vec(page: &DataPage) -> Result<Vec<Option<bool>>> {
     let state = BooleanPageState::try_new(page)?;
 
     match state {
-        BooleanPageState::Optional(validity, values) => deserialize_optional(validity, values),
+        BooleanPageState::Optional(validity, mut values) => {
+            deserialize_optional(validity, values.by_ref().map(Ok))
+        }
         BooleanPageState::Required(bitmap, length) => Ok(BitmapIter::new(bitmap, 0, length)
             .into_iter()
             .map(Some)

--- a/tests/it/read/primitive_nested.rs
+++ b/tests/it/read/primitive_nested.rs
@@ -138,7 +138,7 @@ fn read_array<T: NativeType>(
 }
 
 pub fn page_to_array<T: NativeType>(page: &DataPage) -> Result<Array> {
-    let (rep_levels, def_levels, values) = split_buffer(page);
+    let (rep_levels, def_levels, values) = split_buffer(page)?;
 
     match (&page.encoding(), &page.dictionary_page()) {
         (Encoding::Plain, None) => Ok(read_array::<T>(
@@ -193,7 +193,7 @@ fn read_dict_array<T: NativeType>(
 pub fn page_dict_to_array<T: NativeType>(page: &DataPage) -> Result<Array> {
     assert_eq!(page.descriptor.max_rep_level, 1);
 
-    let (rep_levels, def_levels, values) = split_buffer(page);
+    let (rep_levels, def_levels, values) = split_buffer(page)?;
 
     match (page.encoding(), &page.dictionary_page()) {
         (Encoding::PlainDictionary, Some(dict)) => Ok(read_dict_array::<T>(

--- a/tests/it/read/struct_.rs
+++ b/tests/it/read/struct_.rs
@@ -1,13 +1,14 @@
 use parquet2::encoding::hybrid_rle::HybridRleDecoder;
+use parquet2::error::Error;
 use parquet2::page::{split_buffer, DataPage};
 use parquet2::read::levels::get_bit_width;
 
-pub fn extend_validity(val: &mut Vec<bool>, page: &DataPage) {
-    let (_, def_levels, _) = split_buffer(page);
+pub fn extend_validity(val: &mut Vec<bool>, page: &DataPage) -> Result<(), Error> {
+    let (_, def_levels, _) = split_buffer(page)?;
     let length = page.num_values();
 
     if page.descriptor.max_def_level == 0 {
-        return;
+        return Ok(());
     }
 
     let def_level_encoding = (
@@ -18,4 +19,5 @@ pub fn extend_validity(val: &mut Vec<bool>, page: &DataPage) {
     let def_levels = HybridRleDecoder::new(def_levels, get_bit_width(def_level_encoding.1), length);
 
     val.extend(def_levels.map(|x| x != 0));
+    Ok(())
 }

--- a/tests/it/read/utils.rs
+++ b/tests/it/read/utils.rs
@@ -4,7 +4,7 @@ use parquet2::{
     error::Error,
 };
 
-pub fn deserialize_optional<C: Clone, I: Iterator<Item = C>>(
+pub fn deserialize_optional<C: Clone, I: Iterator<Item = Result<C, Error>>>(
     validity: DefLevelsDecoder,
     values: I,
 ) -> Result<Vec<Option<C>>, Error> {
@@ -16,42 +16,51 @@ pub fn deserialize_optional<C: Clone, I: Iterator<Item = C>>(
     }
 }
 
-fn deserialize_bitmap<C: Clone, I: Iterator<Item = C>>(
-    validity: HybridDecoderBitmapIter,
+fn deserialize_bitmap<C: Clone, I: Iterator<Item = Result<C, Error>>>(
+    mut validity: HybridDecoderBitmapIter,
     mut values: I,
 ) -> Result<Vec<Option<C>>, Error> {
     let mut deserialized = Vec::with_capacity(validity.len());
 
-    validity.for_each(|run| match run {
-        HybridEncoded::Bitmap(bitmap, length) => {
-            BitmapIter::new(bitmap, 0, length)
-                .into_iter()
-                .for_each(|x| {
-                    if x {
-                        deserialized.push(values.next())
-                    } else {
-                        deserialized.push(None)
-                    }
-                });
-        }
+    validity.try_for_each(|run| match run {
+        HybridEncoded::Bitmap(bitmap, length) => BitmapIter::new(bitmap, 0, length)
+            .into_iter()
+            .try_for_each(|x| {
+                if x {
+                    deserialized.push(values.next().transpose()?);
+                } else {
+                    deserialized.push(None);
+                }
+                Result::<_, Error>::Ok(())
+            }),
         HybridEncoded::Repeated(is_set, length) => {
             if is_set {
-                deserialized.extend(values.by_ref().take(length).map(Some))
+                deserialized.reserve(length);
+                for x in values.by_ref().take(length) {
+                    deserialized.push(Some(x?))
+                }
             } else {
                 deserialized.extend(std::iter::repeat(None).take(length))
             }
+            Ok(())
         }
-    });
+    })?;
     Ok(deserialized)
 }
 
-fn deserialize_levels<C: Clone, I: Iterator<Item = C>>(
+fn deserialize_levels<C: Clone, I: Iterator<Item = Result<C, Error>>>(
     levels: HybridRleDecoder,
     max: u32,
     mut values: I,
 ) -> Result<Vec<Option<C>>, Error> {
-    Ok(levels
+    levels
         .into_iter()
-        .map(|x| if x == max { values.next() } else { None })
-        .collect())
+        .map(|x| {
+            if x == max {
+                values.next().transpose()
+            } else {
+                Ok(None)
+            }
+        })
+        .collect()
 }


### PR DESCRIPTION
Removed all panics on invalid data:

* reading schemas is now panic free (there was a bug in the thrift deserialization causing a panic on invalid union input)
* invalid lengths of v1 page of rep and def buffers
* negative compressed and uncompressed sizes in pages
* invalid `i32 -> usize` casts
* invalid RLE-encoded data
* invalid num_bits declarations

It is still possible to abort on OOM when reading invalid pages - when we read pages, we should be aware of the total column size or something and avoid reading pages larger than the file size. We need to think a bit on how we wanna do this.