### PR TITLE
Improved performance of reading

### DIFF
--- a/src/bloom_filter/read.rs
+++ b/src/bloom_filter/read.rs
@@ -38,14 +38,12 @@ pub fn read<R: Read + Seek>(
         bitset.clear();
         return Ok(());
     }
-    // read bitset
-    if header.num_bytes as usize > bitset.capacity() {
-        *bitset = vec![0; header.num_bytes as usize]
-    } else {
-        bitset.clear();
-        bitset.resize(header.num_bytes as usize, 0); // populate with zeros
-    }
 
-    reader.read_exact(bitset)?;
+    let length: usize = header.num_bytes.try_into()?;
+
+    bitset.clear();
+    bitset.try_reserve(length)?;
+    reader.by_ref().take(length as u64).read_to_end(bitset)?;
+
     Ok(())
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -90,6 +90,12 @@ impl From<std::io::Error> for Error {
     }
 }
 
+impl From<std::collections::TryReserveError> for Error {
+    fn from(e: std::collections::TryReserveError) -> Error {
+        Error::General(format!("OOM: {}", e))
+    }
+}
+
 impl From<std::num::TryFromIntError> for Error {
     fn from(e: std::num::TryFromIntError) -> Error {
         Error::OutOfSpec(format!("Number must be zero or positive: {}", e))

--- a/src/read/indexes/read.rs
+++ b/src/read/indexes/read.rs
@@ -90,8 +90,10 @@ pub fn read_columns_indexes<R: Read + Seek>(
     let length = lengths.iter().sum::<usize>();
 
     reader.seek(SeekFrom::Start(offset))?;
-    let mut data = vec![0; length];
-    reader.read_exact(&mut data)?;
+
+    let mut data = vec![];
+    data.try_reserve(length)?;
+    reader.by_ref().take(length as u64).read_to_end(&mut data)?;
 
     deserialize_column_indexes(chunks, &data, lengths)
 }
@@ -122,8 +124,10 @@ pub fn read_pages_locations<R: Read + Seek>(
     let length = lengths.iter().sum::<usize>();
 
     reader.seek(SeekFrom::Start(offset))?;
-    let mut data = vec![0; length];
-    reader.read_exact(&mut data)?;
+
+    let mut data = vec![];
+    data.try_reserve(length)?;
+    reader.by_ref().take(length as u64).read_to_end(&mut data)?;
 
     deserialize_page_locations(&data, chunks.len())
 }

--- a/src/read/page/reader.rs
+++ b/src/read/page/reader.rs
@@ -195,21 +195,15 @@ pub(super) fn build_page<R: Read>(
         .map(|x| x.num_values() as i64)
         .unwrap_or_default();
 
-    let read_size = page_header.compressed_page_size as usize;
-    if read_size > 0 {
-        if read_size > buffer.capacity() {
-            // dealloc and ignore region, replacing it by a new region.
-            // This won't reallocate - it frees and calls `alloc_zeroed`
-            *buffer = vec![0; read_size];
-        } else if read_size > buffer.len() {
-            // fill what we need with zeros so that we can use them in `Read`.
-            // This won't reallocate
-            buffer.resize(read_size, 0);
-        } else {
-            buffer.truncate(read_size);
-        }
-        reader.reader.read_exact(buffer)?;
-    }
+    let read_size: usize = page_header.compressed_page_size.try_into()?;
+
+    buffer.clear();
+    buffer.try_reserve(read_size)?;
+    reader
+        .reader
+        .by_ref()
+        .take(read_size as u64)
+        .read_to_end(buffer)?;
 
     let result = finish_page(
         page_header,


### PR DESCRIPTION
This PR improves the performance of reading (everything) by not zeroying regions when calling `Read`, via `read_to_end`.

Excellent tip by [Kornel](https://users.rust-lang.org/u/kornel/summary) at https://users.rust-lang.org/t/how-to-efficiently-re-use-a-vec-u8-for-multiple-read-read/77628/6 