### PR TITLE
Fix compilation of parquet-tools

### DIFF
--- a/parquet-tools/Cargo.toml
+++ b/parquet-tools/Cargo.toml
@@ -15,5 +15,5 @@ name = "parquet_tools"
 path = "src/main.rs"
 
 [dependencies]
-parquet2 = { version = "0.1", path = "../" }
+parquet2 = { version = "0.14", path = "../" }
 clap = {version = "2.33", features = ["yaml"]}

--- a/src/page/mod.rs
+++ b/src/page/mod.rs
@@ -25,7 +25,7 @@ pub struct CompressedDataPage {
     pub(crate) buffer: Vec<u8>,
     compression: Compression,
     uncompressed_page_size: usize,
-    pub(crate) dictionary_page: Option<Arc<dyn DictPage>>,
+    pub dictionary_page: Option<Arc<dyn DictPage>>,
     pub(crate) descriptor: Descriptor,
 
     // The offset and length in rows


### PR DESCRIPTION
I noticed that the `parquet-tools` crate not longer compiles because of some api changes. This is my quick attempt at fixing it.