### PR TITLE
Add zlib-ng backend for gzip

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ futures = { version = "0.3" }
 
 snap = { version = "^1.0", optional = true }
 brotli = { version = "^3.3", optional = true }
-flate2 = { version = "^1.0", optional = true }
+flate2 = { version = "^1.0", optional = true, default-features = false }
 lz4 = { version = "1.23.3", optional = true }
 zstd = { version = "^0.11", optional = true, default-features = false }
 lz4_flex = { version = "^0.9.2", optional = true }
@@ -39,7 +39,8 @@ rand = "0.8"
 [features]
 default = ["snappy", "gzip", "lz4", "zstd", "brotli", "bloom_filter"]
 snappy = ["snap"]
-gzip = ["flate2"]
+gzip = ["flate2/rust_backend"]
+gzip_zlib_ng = ["flate2/zlib-ng"]
 bloom_filter = ["xxhash-rust"]
 
 [[bench]]


### PR DESCRIPTION
This PR proposes to use the zlib-ng backend for gzip. It is up 2.5x faster than the default backend. Some benchmarks here:

https://github.com/Byron/gitoxide/issues/1#issuecomment-672626465.

~Maybe you want to optional as feature flag?~

Edit: made it an optional feature flag