### PR TITLE
Improved indexed API

### DIFF
--- a/src/indexes/intervals.rs
+++ b/src/indexes/intervals.rs
@@ -1,3 +1,5 @@
+use std::collections::VecDeque;
+
 use parquet_format_async_temp::PageLocation;
 
 use crate::error::Error;
@@ -103,7 +105,7 @@ pub fn select_pages(
     intervals: &[Interval],
     locations: &[PageLocation],
     num_rows: usize,
-) -> Result<Vec<FilteredPage>, Error> {
+) -> Result<VecDeque<FilteredPage>, Error> {
     let page_intervals = compute_page_row_intervals(locations, num_rows)?;
 
     page_intervals

--- a/src/indexes/mod.rs
+++ b/src/indexes/mod.rs
@@ -63,7 +63,7 @@ mod tests {
         let selector = |page: &PageIndex<Vec<u8>>| {
             page.max
                 .as_ref()
-                .map(|x| x.as_slice() > &[97])
+                .map(|x| x.as_slice()[0] > 97)
                 .unwrap_or(false) // no max is present => all nulls => not selected
         };
         let selected = index.indexes.iter().map(selector).collect::<Vec<_>>();

--- a/src/metadata/sort.rs
+++ b/src/metadata/sort.rs
@@ -10,7 +10,7 @@ use crate::schema::types::{
 ///
 /// See reference in
 /// <https://github.com/apache/parquet-cpp/blob/master/src/parquet/types.h>
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum SortOrder {
     /// Signed (either value or legacy byte-wise) comparison.
     Signed,

--- a/src/read/metadata.rs
+++ b/src/read/metadata.rs
@@ -1,7 +1,7 @@
 use std::convert::TryInto;
 use std::{
     cmp::min,
-    io::{Cursor, Read, Seek, SeekFrom},
+    io::{Read, Seek, SeekFrom},
 };
 
 use parquet_format_async_temp::thrift::protocol::TCompactInputProtocol;
@@ -31,21 +31,13 @@ fn stream_len(seek: &mut impl Seek) -> std::result::Result<u64, std::io::Error> 
     Ok(len)
 }
 
-/// Reads a file's metadata.
-// Layout of Parquet file
-// +---------------------------+-----+---+
-// |      Rest of file         |  B  | A |
-// +---------------------------+-----+---+
-// where A: parquet footer, B: parquet metadata.
-//
-// The reader first reads DEFAULT_FOOTER_SIZE bytes from the end of the file.
-// If it is not enough according to the length indicated in the footer, it reads more bytes.
+/// Reads from the end of the reader a [`FileMetaData`].
 pub fn read_metadata<R: Read + Seek>(reader: &mut R) -> Result<FileMetaData> {
     // check file is large enough to hold footer
     let file_size = stream_len(reader)?;
     if file_size < HEADER_SIZE + FOOTER_SIZE {
-        return Err(general_err!(
-            "Invalid Parquet file. Size is smaller than header + footer"
+        return Err(Error::OutOfSpec(
+            "A parquet file must containt a header and footer with at least 12 bytes".to_string(),
         ));
     }
 
@@ -61,45 +53,35 @@ pub fn read_metadata<R: Read + Seek>(reader: &mut R) -> Result<FileMetaData> {
 
     // check this is indeed a parquet file
     if buffer[default_end_len - 4..] != PARQUET_MAGIC {
-        return Err(general_err!("Invalid Parquet file. Corrupt footer"));
+        return Err(Error::OutOfSpec(
+            "Invalid Parquet file. Corrupt footer".to_string(),
+        ));
     }
 
-    let metadata = metadata_len(&buffer, default_end_len);
+    let metadata_len = metadata_len(&buffer, default_end_len);
 
-    let metadata_len: u64 = metadata.try_into().map_err(|_| {
-        general_err!(
-            "Invalid Parquet file. Metadata length is less than zero ({})",
-            metadata
-        )
-    })?;
+    let metadata_len: u64 = metadata_len.try_into()?;
 
     let footer_len = FOOTER_SIZE + metadata_len;
     if footer_len > file_size {
-        return Err(general_err!(
-            "Invalid Parquet file. Metadata start is less than zero ({})",
-            file_size as i64 - footer_len as i64
+        return Err(Error::OutOfSpec(
+            "The footer size must be smaller or equal to the file's size".to_string(),
         ));
     }
 
     let reader = if (footer_len as usize) < buffer.len() {
         // the whole metadata is in the bytes we already read
-        // build up the reader covering the entire metadata
-        let mut reader = Cursor::new(buffer);
-        reader.seek(SeekFrom::End(-(footer_len as i64)))?;
-
-        reader
+        let remaining = buffer.len() - footer_len as usize;
+        &buffer[remaining..]
     } else {
-        // the end of file read by default is not long enough, read again including all metadata.
+        // the end of file read by default is not long enough, read again including the metadata.
         reader.seek(SeekFrom::End(-(footer_len as i64)))?;
 
         buffer.clear();
         buffer.try_reserve(footer_len as usize)?;
-        reader
-            .by_ref()
-            .take(footer_len as u64)
-            .read_to_end(&mut buffer)?;
+        reader.take(footer_len as u64).read_to_end(&mut buffer)?;
 
-        Cursor::new(buffer)
+        &buffer
     };
 
     deserialize_metadata(reader)

--- a/src/read/page/indexed_reader.rs
+++ b/src/read/page/indexed_reader.rs
@@ -96,7 +96,7 @@ impl<R: Read + Seek> IndexedPageReader<R> {
     pub fn new(
         reader: R,
         column: &ColumnChunkMetaData,
-        pages: Vec<FilteredPage>,
+        pages: VecDeque<FilteredPage>,
         buffer: Vec<u8>,
         data_buffer: Vec<u8>,
     ) -> Self {
@@ -107,7 +107,7 @@ impl<R: Read + Seek> IndexedPageReader<R> {
     pub fn new_with_page_meta(
         reader: R,
         column: PageMetaData,
-        pages: Vec<FilteredPage>,
+        pages: VecDeque<FilteredPage>,
         buffer: Vec<u8>,
         data_buffer: Vec<u8>,
     ) -> Self {

--- a/src/read/page/reader.rs
+++ b/src/read/page/reader.rs
@@ -17,7 +17,7 @@ use crate::parquet_bridge::Encoding;
 use super::PageIterator;
 
 /// This meta is a small part of [`ColumnChunkMetaData`].
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PageMetaData {
     /// The start offset of this column chunk in file.
     pub column_start: u64,

--- a/src/schema/io_message/from_message.rs
+++ b/src/schema/io_message/from_message.rs
@@ -71,14 +71,28 @@ fn is_logical_type(s: &str) -> bool {
 }
 
 fn is_converted_type(s: &str) -> bool {
-    match s {
-        "UTF8" | "ENUM" | "DECIMAL" | "DATE" | "TIME_MILLIS" | "TIME_MICROS"
-        | "TIMESTAMP_MILLIS" | "TIMESTAMP_MICROS" | "UINT_8" | "UINT_16" | "UINT_32"
-        | "UINT_64" | "INT_8" | "INT_16" | "INT_32" | "INT_64" | "JSON" | "BSON" | "INTERVAL" => {
-            true
-        }
-        _ => false,
-    }
+    matches!(
+        s,
+        "UTF8"
+            | "ENUM"
+            | "DECIMAL"
+            | "DATE"
+            | "TIME_MILLIS"
+            | "TIME_MICROS"
+            | "TIMESTAMP_MILLIS"
+            | "TIMESTAMP_MICROS"
+            | "UINT_8"
+            | "UINT_16"
+            | "UINT_32"
+            | "UINT_64"
+            | "INT_8"
+            | "INT_16"
+            | "INT_32"
+            | "INT_64"
+            | "JSON"
+            | "BSON"
+            | "INTERVAL"
+    )
 }
 
 fn converted_group_from_str(s: &str) -> Result<GroupConvertedType> {

--- a/src/statistics/binary.rs
+++ b/src/statistics/binary.rs
@@ -8,7 +8,7 @@ use crate::{
     schema::types::{PhysicalType, PrimitiveType},
 };
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BinaryStatistics {
     pub primitive_type: PrimitiveType,
     pub null_count: Option<i64>,

--- a/src/statistics/boolean.rs
+++ b/src/statistics/boolean.rs
@@ -8,7 +8,7 @@ use crate::{
     schema::types::PhysicalType,
 };
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BooleanStatistics {
     pub null_count: Option<i64>,
     pub distinct_count: Option<i64>,
@@ -49,8 +49,16 @@ pub fn read(v: &ParquetStatistics) -> Result<Arc<dyn Statistics>> {
     Ok(Arc::new(BooleanStatistics {
         null_count: v.null_count,
         distinct_count: v.distinct_count,
-        max_value: v.max_value.as_ref().and_then(|x| x.get(0)).map(|x| *x != 0),
-        min_value: v.min_value.as_ref().and_then(|x| x.get(0)).map(|x| *x != 0),
+        max_value: v
+            .max_value
+            .as_ref()
+            .and_then(|x| x.first())
+            .map(|x| *x != 0),
+        min_value: v
+            .min_value
+            .as_ref()
+            .and_then(|x| x.first())
+            .map(|x| *x != 0),
     }))
 }
 

--- a/src/statistics/fixed_len_binary.rs
+++ b/src/statistics/fixed_len_binary.rs
@@ -8,7 +8,7 @@ use crate::{
     schema::types::{PhysicalType, PrimitiveType},
 };
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FixedLenStatistics {
     pub primitive_type: PrimitiveType,
     pub null_count: Option<i64>,

--- a/src/statistics/primitive.rs
+++ b/src/statistics/primitive.rs
@@ -7,7 +7,7 @@ use crate::error::{Error, Result};
 use crate::schema::types::{PhysicalType, PrimitiveType};
 use crate::types;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PrimitiveStatistics<T: types::NativeType> {
     pub primitive_type: PrimitiveType,
     pub null_count: Option<i64>,


### PR DESCRIPTION
This is backward incompatible - `Vec<FilteredPage>` -> `VecDeque<FilteredPage>`. This is because usually pages are read from the start and thus `pop_front` is a more natural API for them.