### PR TITLE
Fixed OOM on malicious/malformed thrift

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ name = "parquet2"
 bench = false
 
 [dependencies]
-parquet-format-async-temp = "0.3.1"
+parquet-format-safe = "0.1"
 bitpacking = { version = "0.8.2", default-features = false, features = ["bitpacker1x"] }
 streaming-decompression = "0.1"
 

--- a/examples/read_metadata.rs
+++ b/examples/read_metadata.rs
@@ -118,7 +118,7 @@ fn main() -> Result<()> {
 
     // ANCHOR: pages
     use parquet2::read::get_page_iterator;
-    let pages = get_page_iterator(column_metadata, &mut reader, None, vec![])?;
+    let pages = get_page_iterator(column_metadata, &mut reader, None, vec![], 1024 * 1024)?;
     // ANCHOR_END: pages
 
     // ANCHOR: decompress

--- a/src/bloom_filter/read.rs
+++ b/src/bloom_filter/read.rs
@@ -1,6 +1,6 @@
 use std::io::{Read, Seek, SeekFrom};
 
-use parquet_format_async_temp::{
+use parquet_format_safe::{
     thrift::protocol::TCompactInputProtocol, BloomFilterAlgorithm, BloomFilterCompression,
     BloomFilterHeader, SplitBlockAlgorithm, Uncompressed,
 };
@@ -27,7 +27,7 @@ pub fn read<R: Read + Seek>(
     reader.seek(SeekFrom::Start(offset))?;
 
     // deserialize header
-    let mut prot = TCompactInputProtocol::new(&mut reader);
+    let mut prot = TCompactInputProtocol::new(&mut reader, usize::MAX); // max is ok since `BloomFilterHeader` never allocates
     let header = BloomFilterHeader::read_from_in_protocol(&mut prot)?;
 
     if header.algorithm != BloomFilterAlgorithm::BLOCK(SplitBlockAlgorithm {}) {

--- a/src/error.rs
+++ b/src/error.rs
@@ -78,8 +78,8 @@ impl From<lz4_flex::block::CompressError> for Error {
     }
 }
 
-impl From<parquet_format_async_temp::thrift::Error> for Error {
-    fn from(e: parquet_format_async_temp::thrift::Error) -> Error {
+impl From<parquet_format_safe::thrift::Error> for Error {
+    fn from(e: parquet_format_safe::thrift::Error) -> Error {
         Error::General(format!("underlying thrift error: {}", e))
     }
 }

--- a/src/indexes/index.rs
+++ b/src/indexes/index.rs
@@ -1,6 +1,6 @@
 use std::any::Any;
 
-use parquet_format_async_temp::ColumnIndex;
+use parquet_format_safe::ColumnIndex;
 
 use crate::parquet_bridge::BoundaryOrder;
 use crate::schema::types::PrimitiveType;

--- a/src/indexes/intervals.rs
+++ b/src/indexes/intervals.rs
@@ -1,4 +1,4 @@
-use parquet_format_async_temp::PageLocation;
+use parquet_format_safe::PageLocation;
 
 use crate::error::Error;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ pub mod statistics;
 pub mod types;
 pub mod write;
 
-use parquet_format_async_temp as thrift_format;
+use parquet_format_safe as thrift_format;
 
 pub use streaming_decompression::fallible_streaming_iterator;
 pub use streaming_decompression::FallibleStreamingIterator;

--- a/src/metadata/file_metadata.rs
+++ b/src/metadata/file_metadata.rs
@@ -1,12 +1,12 @@
 use crate::{error::Error, metadata::get_sort_order};
 
 use super::{column_order::ColumnOrder, schema_descriptor::SchemaDescriptor, RowGroupMetaData};
-use parquet_format_async_temp::ColumnOrder as TColumnOrder;
+use parquet_format_safe::ColumnOrder as TColumnOrder;
 
 pub use crate::thrift_format::KeyValue;
 
 /// Metadata for a Parquet file.
-// This is almost equal to [`parquet_format_async_temp::FileMetaData`] but contains the descriptors,
+// This is almost equal to [`parquet_format_safe::FileMetaData`] but contains the descriptors,
 // which are crucial to deserialize pages.
 #[derive(Debug, Clone)]
 pub struct FileMetaData {
@@ -60,9 +60,7 @@ impl FileMetaData {
     }
 
     /// Deserializes [`crate::thrift_format::FileMetaData`] into this struct
-    pub fn try_from_thrift(
-        metadata: parquet_format_async_temp::FileMetaData,
-    ) -> Result<Self, Error> {
+    pub fn try_from_thrift(metadata: parquet_format_safe::FileMetaData) -> Result<Self, Error> {
         let schema_descr = SchemaDescriptor::try_from_thrift(&metadata.schema)?;
 
         let row_groups = metadata
@@ -86,9 +84,9 @@ impl FileMetaData {
         })
     }
 
-    /// Serializes itself to thrift's [`parquet_format_async_temp::FileMetaData`].
-    pub fn into_thrift(self) -> parquet_format_async_temp::FileMetaData {
-        parquet_format_async_temp::FileMetaData {
+    /// Serializes itself to thrift's [`parquet_format_safe::FileMetaData`].
+    pub fn into_thrift(self) -> parquet_format_safe::FileMetaData {
+        parquet_format_safe::FileMetaData {
             version: self.version,
             schema: self.schema_descr.into_thrift(),
             num_rows: self.num_rows as i64,

--- a/src/metadata/row_metadata.rs
+++ b/src/metadata/row_metadata.rs
@@ -1,4 +1,4 @@
-use parquet_format_async_temp::RowGroup;
+use parquet_format_safe::RowGroup;
 
 use super::{column_chunk_metadata::ColumnChunkMetaData, schema_descriptor::SchemaDescriptor};
 use crate::{

--- a/src/metadata/schema_descriptor.rs
+++ b/src/metadata/schema_descriptor.rs
@@ -1,4 +1,4 @@
-use parquet_format_async_temp::SchemaElement;
+use parquet_format_safe::SchemaElement;
 
 use crate::{
     error::Error,

--- a/src/read/compression.rs
+++ b/src/read/compression.rs
@@ -1,4 +1,4 @@
-use parquet_format_async_temp::DataPageHeaderV2;
+use parquet_format_safe::DataPageHeaderV2;
 use streaming_decompression;
 
 use crate::compression::{self, Compression};

--- a/src/read/indexes/deserialize.rs
+++ b/src/read/indexes/deserialize.rs
@@ -1,6 +1,4 @@
-use std::io::Cursor;
-
-use parquet_format_async_temp::{thrift::protocol::TCompactInputProtocol, ColumnIndex};
+use parquet_format_safe::{thrift::protocol::TCompactInputProtocol, ColumnIndex};
 
 use crate::error::Error;
 use crate::schema::types::{PhysicalType, PrimitiveType};
@@ -8,8 +6,7 @@ use crate::schema::types::{PhysicalType, PrimitiveType};
 use crate::indexes::{BooleanIndex, ByteIndex, FixedLenByteIndex, Index, NativeIndex};
 
 pub fn deserialize(data: &[u8], primitive_type: PrimitiveType) -> Result<Box<dyn Index>, Error> {
-    let mut d = Cursor::new(data);
-    let mut prot = TCompactInputProtocol::new(&mut d);
+    let mut prot = TCompactInputProtocol::new(data, data.len() * 2 + 1024);
 
     let index = ColumnIndex::read_from_in_protocol(&mut prot)?;
 

--- a/src/read/page/indexed_reader.rs
+++ b/src/read/page/indexed_reader.rs
@@ -60,7 +60,7 @@ fn read_page<R: Read + Seek>(
 
     // deserialize [header]
     let mut reader = Cursor::new(buffer);
-    let page_header = read_page_header(&mut reader)?;
+    let page_header = read_page_header(&mut reader, 1024 * 1024)?;
     let header_size = reader.seek(SeekFrom::Current(0)).unwrap() as usize;
     let buffer = reader.into_inner();
 

--- a/src/read/page/stream.rs
+++ b/src/read/page/stream.rs
@@ -3,7 +3,7 @@ use std::io::SeekFrom;
 use async_stream::try_stream;
 use futures::io::{copy, sink};
 use futures::{AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt, Stream};
-use parquet_format_async_temp::thrift::protocol::TCompactInputStreamProtocol;
+use parquet_format_safe::thrift::protocol::TCompactInputStreamProtocol;
 
 use crate::compression::Compression;
 use crate::error::Result;
@@ -17,18 +17,27 @@ use super::PageFilter;
 pub async fn get_page_stream<'a, RR: AsyncRead + Unpin + Send + AsyncSeek>(
     column_metadata: &'a ColumnChunkMetaData,
     reader: &'a mut RR,
-    buffer: Vec<u8>,
+    scratch: Vec<u8>,
     pages_filter: PageFilter,
+    max_header_size: usize,
 ) -> Result<impl Stream<Item = Result<CompressedPage>> + 'a> {
-    get_page_stream_with_page_meta(column_metadata.into(), reader, buffer, pages_filter).await
+    get_page_stream_with_page_meta(
+        column_metadata.into(),
+        reader,
+        scratch,
+        pages_filter,
+        max_header_size,
+    )
+    .await
 }
 
 /// Returns a stream of compressed data pages from a reader that begins at the start of the column
 pub async fn get_page_stream_from_column_start<'a, R: AsyncRead + Unpin + Send>(
     column_metadata: &'a ColumnChunkMetaData,
     reader: &'a mut R,
-    buffer: Vec<u8>,
+    scratch: Vec<u8>,
     pages_filter: PageFilter,
+    max_header_size: usize,
 ) -> Result<impl Stream<Item = Result<CompressedPage>> + 'a> {
     let page_metadata: PageMetaData = column_metadata.into();
     Ok(_get_page_stream(
@@ -36,8 +45,9 @@ pub async fn get_page_stream_from_column_start<'a, R: AsyncRead + Unpin + Send>(
         page_metadata.num_values,
         page_metadata.compression,
         page_metadata.descriptor,
-        buffer,
+        scratch,
         pages_filter,
+        max_header_size,
     ))
 }
 
@@ -45,8 +55,9 @@ pub async fn get_page_stream_from_column_start<'a, R: AsyncRead + Unpin + Send>(
 pub async fn get_page_stream_with_page_meta<RR: AsyncRead + Unpin + Send + AsyncSeek>(
     page_metadata: PageMetaData,
     reader: &mut RR,
-    buffer: Vec<u8>,
+    scratch: Vec<u8>,
     pages_filter: PageFilter,
+    max_header_size: usize,
 ) -> Result<impl Stream<Item = Result<CompressedPage>> + '_> {
     let column_start = page_metadata.column_start;
     reader.seek(SeekFrom::Start(column_start)).await?;
@@ -55,8 +66,9 @@ pub async fn get_page_stream_with_page_meta<RR: AsyncRead + Unpin + Send + Async
         page_metadata.num_values,
         page_metadata.compression,
         page_metadata.descriptor,
-        buffer,
+        scratch,
         pages_filter,
+        max_header_size,
     ))
 }
 
@@ -65,14 +77,15 @@ fn _get_page_stream<R: AsyncRead + Unpin + Send>(
     total_num_values: i64,
     compression: Compression,
     descriptor: Descriptor,
-    mut buffer: Vec<u8>,
+    mut scratch: Vec<u8>,
     pages_filter: PageFilter,
+    max_header_size: usize,
 ) -> impl Stream<Item = Result<CompressedPage>> + '_ {
     let mut seen_values = 0i64;
     try_stream! {
         while seen_values < total_num_values {
             // the header
-            let page_header = read_page_header(reader).await?;
+            let page_header = read_page_header(reader, max_header_size).await?;
 
             let data_header = get_page_header(&page_header)?;
             seen_values += data_header.as_ref().map(|x| x.num_values() as i64).unwrap_or_default();
@@ -88,15 +101,15 @@ fn _get_page_stream<R: AsyncRead + Unpin + Send>(
             }
 
             // followed by the buffer
-            buffer.clear();
-            buffer.try_reserve(read_size)?;
+            scratch.clear();
+            scratch.try_reserve(read_size)?;
             reader
                 .take(read_size as u64)
-                .read_to_end(&mut buffer).await?;
+                .read_to_end(&mut scratch).await?;
 
             yield finish_page(
                 page_header,
-                &mut buffer,
+                &mut scratch,
                 compression,
                 &descriptor,
                 None,
@@ -108,8 +121,9 @@ fn _get_page_stream<R: AsyncRead + Unpin + Send>(
 /// Reads Page header from Thrift.
 async fn read_page_header<R: AsyncRead + Unpin + Send>(
     reader: &mut R,
+    max_header_size: usize,
 ) -> Result<ParquetPageHeader> {
-    let mut prot = TCompactInputStreamProtocol::new(reader);
+    let mut prot = TCompactInputStreamProtocol::new(reader, max_header_size);
     let page_header = ParquetPageHeader::stream_from_in_protocol(&mut prot).await?;
     Ok(page_header)
 }

--- a/src/read/stream.rs
+++ b/src/read/stream.rs
@@ -82,5 +82,8 @@ pub async fn read_metadata<R: AsyncRead + AsyncSeek + Send + std::marker::Unpin>
         &buffer
     };
 
-    deserialize_metadata(reader)
+    // a highly nested but sparse struct could result in many allocations
+    let max_size = reader.len() * 2 + 1024;
+
+    deserialize_metadata(reader, max_size)
 }

--- a/src/schema/io_message/from_message.rs
+++ b/src/schema/io_message/from_message.rs
@@ -42,7 +42,7 @@
 //! println!("{:?}", schema);
 //! ```
 
-use parquet_format_async_temp::Type;
+use parquet_format_safe::Type;
 use types::PrimitiveLogicalType;
 
 use super::super::types::{ParquetType, TimeUnit};

--- a/src/schema/io_thrift/from_thrift.rs
+++ b/src/schema/io_thrift/from_thrift.rs
@@ -1,4 +1,4 @@
-use parquet_format_async_temp::SchemaElement;
+use parquet_format_safe::SchemaElement;
 
 use crate::{
     error::{Error, Result},

--- a/src/schema/io_thrift/to_thrift.rs
+++ b/src/schema/io_thrift/to_thrift.rs
@@ -1,4 +1,4 @@
-use parquet_format_async_temp::{ConvertedType, SchemaElement};
+use parquet_format_safe::{ConvertedType, SchemaElement};
 
 use crate::schema::types::PrimitiveType;
 

--- a/src/schema/types/converted_type.rs
+++ b/src/schema/types/converted_type.rs
@@ -1,5 +1,5 @@
 use crate::error::Error;
-use parquet_format_async_temp::ConvertedType;
+use parquet_format_safe::ConvertedType;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum PrimitiveConvertedType {

--- a/src/schema/types/physical_type.rs
+++ b/src/schema/types/physical_type.rs
@@ -1,4 +1,4 @@
-use parquet_format_async_temp::Type;
+use parquet_format_safe::Type;
 
 use crate::error::Error;
 

--- a/src/statistics/binary.rs
+++ b/src/statistics/binary.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use parquet_format_async_temp::Statistics as ParquetStatistics;
+use parquet_format_safe::Statistics as ParquetStatistics;
 
 use super::Statistics;
 use crate::{

--- a/src/statistics/boolean.rs
+++ b/src/statistics/boolean.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use parquet_format_async_temp::Statistics as ParquetStatistics;
+use parquet_format_safe::Statistics as ParquetStatistics;
 
 use super::Statistics;
 use crate::{

--- a/src/statistics/fixed_len_binary.rs
+++ b/src/statistics/fixed_len_binary.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use parquet_format_async_temp::Statistics as ParquetStatistics;
+use parquet_format_safe::Statistics as ParquetStatistics;
 
 use super::Statistics;
 use crate::{

--- a/src/statistics/primitive.rs
+++ b/src/statistics/primitive.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use parquet_format_async_temp::Statistics as ParquetStatistics;
+use parquet_format_safe::Statistics as ParquetStatistics;
 
 use super::Statistics;
 use crate::error::{Error, Result};

--- a/src/write/column_chunk.rs
+++ b/src/write/column_chunk.rs
@@ -2,10 +2,10 @@ use std::collections::HashSet;
 use std::io::Write;
 
 use futures::AsyncWrite;
-use parquet_format_async_temp::thrift::protocol::{
+use parquet_format_safe::thrift::protocol::{
     TCompactOutputProtocol, TCompactOutputStreamProtocol, TOutputProtocol, TOutputStreamProtocol,
 };
-use parquet_format_async_temp::{ColumnChunk, ColumnMetaData, Type};
+use parquet_format_safe::{ColumnChunk, ColumnMetaData, Type};
 
 use crate::statistics::serialize_statistics;
 use crate::FallibleStreamingIterator;

--- a/src/write/file.rs
+++ b/src/write/file.rs
@@ -1,8 +1,8 @@
 use std::io::Write;
 
-use parquet_format_async_temp::thrift::protocol::TCompactOutputProtocol;
-use parquet_format_async_temp::thrift::protocol::TOutputProtocol;
-use parquet_format_async_temp::RowGroup;
+use parquet_format_safe::thrift::protocol::TCompactOutputProtocol;
+use parquet_format_safe::thrift::protocol::TOutputProtocol;
+use parquet_format_safe::RowGroup;
 
 use crate::metadata::ThriftFileMetaData;
 use crate::{
@@ -273,6 +273,7 @@ mod tests {
 
         // read it again:
         let result = read_metadata(&mut Cursor::new(a));
+        println!("{result:?}");
         assert!(result.is_ok());
 
         Ok(())

--- a/src/write/indexes/serialize.rs
+++ b/src/write/indexes/serialize.rs
@@ -1,7 +1,7 @@
-use parquet_format_async_temp::BoundaryOrder;
-use parquet_format_async_temp::ColumnIndex;
-use parquet_format_async_temp::OffsetIndex;
-use parquet_format_async_temp::PageLocation;
+use parquet_format_safe::BoundaryOrder;
+use parquet_format_safe::ColumnIndex;
+use parquet_format_safe::OffsetIndex;
+use parquet_format_safe::PageLocation;
 
 use crate::error::{Error, Result};
 pub use crate::metadata::KeyValue;

--- a/src/write/indexes/write.rs
+++ b/src/write/indexes/write.rs
@@ -1,9 +1,7 @@
 use futures::AsyncWrite;
 use std::io::Write;
 
-use parquet_format_async_temp::thrift::protocol::{
-    TCompactOutputProtocol, TCompactOutputStreamProtocol,
-};
+use parquet_format_safe::thrift::protocol::{TCompactOutputProtocol, TCompactOutputStreamProtocol};
 
 use crate::error::Result;
 pub use crate::metadata::KeyValue;

--- a/src/write/page.rs
+++ b/src/write/page.rs
@@ -3,10 +3,8 @@ use std::io::Write;
 use std::sync::Arc;
 
 use futures::{AsyncWrite, AsyncWriteExt};
-use parquet_format_async_temp::thrift::protocol::{
-    TCompactOutputProtocol, TCompactOutputStreamProtocol,
-};
-use parquet_format_async_temp::{DictionaryPageHeader, Encoding, PageType};
+use parquet_format_safe::thrift::protocol::{TCompactOutputProtocol, TCompactOutputStreamProtocol};
+use parquet_format_safe::{DictionaryPageHeader, Encoding, PageType};
 
 use crate::compression::Compression;
 use crate::error::{Error, Result};

--- a/src/write/row_group.rs
+++ b/src/write/row_group.rs
@@ -1,7 +1,7 @@
 use std::io::Write;
 
 use futures::AsyncWrite;
-use parquet_format_async_temp::{ColumnChunk, RowGroup};
+use parquet_format_safe::{ColumnChunk, RowGroup};
 
 use crate::{
     error::{Error, Result},

--- a/src/write/stream.rs
+++ b/src/write/stream.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 
 use futures::{AsyncWrite, AsyncWriteExt};
 
-use parquet_format_async_temp::{
+use parquet_format_safe::{
     thrift::protocol::{TCompactOutputStreamProtocol, TOutputStreamProtocol},
     FileMetaData, RowGroup,
 };

--- a/tests/it/read/mod.rs
+++ b/tests/it/read/mod.rs
@@ -225,7 +225,15 @@ pub fn read_column<R: std::io::Read + std::io::Seek>(
         .next()
         .ok_or_else(|| Error::OutOfSpec("column does not exist".to_string()))?;
 
-    let columns = get_column_iterator(reader, &metadata, row_group, field, None, vec![]);
+    let columns = get_column_iterator(
+        reader,
+        &metadata,
+        row_group,
+        field,
+        None,
+        vec![],
+        usize::MAX,
+    );
     let field = &metadata.schema().fields()[field];
 
     let mut statistics = get_field_columns(&metadata, row_group, field)
@@ -257,7 +265,8 @@ pub async fn read_column_async<
 
     let column = &metadata.row_groups[0].columns()[0];
 
-    let pages = get_page_stream(column, reader, vec![], Arc::new(|_, _| true)).await?;
+    let pages = get_page_stream(column, reader, vec![], Arc::new(|_, _| true), usize::MAX).await?;
+
     let field = &metadata.schema().fields()[field];
 
     let mut statistics = get_field_columns(&metadata, row_group, field)


### PR DESCRIPTION
This PR is built on top of https://github.com/jorgecarleitao/parquet-format-safe/pull/1 and eliminates OOMs and some `panics!` when reading malformed/malicious thrift.

A big thanks to @evanrichter that responsibility disclosed this privately to me, and to contributors at https://users.rust-lang.org/t/how-to-avoid-oom-when-reading-untrusted-sources/79263?u=jorgecarleitao that significantly clarified the different aspects of reading from untrusted sources.

This still does not protect us from [zip bombs](https://en.wikipedia.org/wiki/Zip_bomb) in OOM, and there are still a lot of panics around - we will require a second read parameter to address them when decompressing (e.g. very large but repetitive strings).

On a positive note, fuzzing did not UB, so the first line of defense (`forbid(unsafe_code)` and careful review of dependencies) is working as intended.

On a side note, after some digging, the ability to OOM and/or panic on malicious data is a recurrent problem on a _significant_ part of this ecosystem (thrift, flatbuffers).

I plan to create an advisory against parquet2 to inform our users, but this will be a process since there are a bunch of places where we currently panic (and the ecosystem seems to be ok with this). For this reason we agreed to not have an embargo at this point.

The long term idea here is that having a reader that does not panic/OOM on invalid data allows these formats to be safely used beyond very sandboxed / restricted environments.

For now, the primary goal is to not have OOM, since it by default aborts the process.

Close #173