### PR TITLE
Improved `Error`

### DIFF
--- a/src/deserialize/binary.rs
+++ b/src/deserialize/binary.rs
@@ -63,8 +63,8 @@ impl<'a, P> BinaryPageState<'a, P> {
 
                 Ok(Self::Required(values))
             }
-            _ => Err(Error::General(format!(
-                "Viewing page for encoding {:?} for binary type not supported",
+            _ => Err(Error::FeatureNotSupported(format!(
+                "Viewing page for encoding {:?} for binary type",
                 page.encoding(),
             ))),
         }

--- a/src/deserialize/boolean.rs
+++ b/src/deserialize/boolean.rs
@@ -33,7 +33,7 @@ impl<'a> BooleanPageState<'a> {
                 let (_, _, values) = split_buffer(page)?;
                 Ok(Self::Required(values, page.num_values()))
             }
-            _ => Err(Error::General(format!(
+            _ => Err(Error::InvalidParameter(format!(
                 "Viewing page for encoding {:?} for boolean type not supported",
                 page.encoding(),
             ))),

--- a/src/deserialize/fixed_len.rs
+++ b/src/deserialize/fixed_len.rs
@@ -71,7 +71,7 @@ impl<'a, P> FixedLenBinaryPageState<'a, P> {
         {
             size
         } else {
-            return Err(Error::General(
+            return Err(Error::InvalidParameter(
                 "FixedLenBinaryPageState must be initialized by pages of FixedLenByteArray"
                     .to_string(),
             ));
@@ -101,8 +101,8 @@ impl<'a, P> FixedLenBinaryPageState<'a, P> {
 
                 Ok(Self::Required(values))
             }
-            _ => Err(Error::General(format!(
-                "Viewing page for encoding {:?} for binary type not supported",
+            _ => Err(Error::FeatureNotSupported(format!(
+                "Viewing page for encoding {:?} for binary type",
                 page.encoding(),
             ))),
         }

--- a/src/deserialize/native.rs
+++ b/src/deserialize/native.rs
@@ -15,8 +15,8 @@ pub type Casted<'a, T> = std::iter::Map<std::slice::ChunksExact<'a, u8>, fn(&'a 
 pub fn native_cast<T: NativeType>(page: &DataPage) -> Result<Casted<T>, Error> {
     let (_, _, values) = split_buffer(page)?;
     if values.len() % std::mem::size_of::<T>() != 0 {
-        return Err(Error::OutOfSpec(
-            "A primitive page data's len must be a multiple of the type".to_string(),
+        return Err(Error::oos(
+            "A primitive page data's len must be a multiple of the type",
         ));
     }
 
@@ -90,8 +90,8 @@ impl<'a, T: NativeType, P> NativePageState<'a, T, P> {
                 Ok(Self::Optional(validity, values))
             }
             (Encoding::Plain, _, false) => native_cast(page).map(Self::Required),
-            _ => Err(Error::General(format!(
-                "Viewing page for encoding {:?} for native type {} not supported",
+            _ => Err(Error::FeatureNotSupported(format!(
+                "Viewing page for encoding {:?} for native type {}",
                 page.encoding(),
                 std::any::type_name::<T>()
             ))),

--- a/src/deserialize/utils.rs
+++ b/src/deserialize/utils.rs
@@ -17,8 +17,8 @@ pub(super) fn dict_indices_decoder(page: &DataPage) -> Result<hybrid_rle::Hybrid
     // SPEC: followed by the values encoded using RLE/Bit packed described above (with the given bit width).
     let bit_width = indices_buffer[0];
     if bit_width > 32 {
-        return Err(Error::OutOfSpec(
-            "Bit width of dictionary pages cannot be larger than 32".to_string(),
+        return Err(Error::oos(
+            "Bit width of dictionary pages cannot be larger than 32",
         ));
     }
     let indices_buffer = &indices_buffer[1..];

--- a/src/encoding/plain_byte_array.rs
+++ b/src/encoding/plain_byte_array.rs
@@ -30,8 +30,8 @@ impl<'a> Iterator for BinaryIter<'a> {
         let length = u32::from_le_bytes(self.values[0..4].try_into().unwrap()) as usize;
         self.values = &self.values[4..];
         if length > self.values.len() {
-            return Some(Err(Error::OutOfSpec(
-                "A string in plain encoding declares a length that is out of range".to_string(),
+            return Some(Err(Error::oos(
+                "A string in plain encoding declares a length that is out of range",
             )));
         }
         let (result, remaining) = self.values.split_at(length);

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,4 @@
 //! Contains [`Error`]
-use std::sync::Arc;
 
 /// List of features whose non-activation may cause a runtime error.
 /// Used to indicate which lack of feature caused [`Error::FeatureNotActive`].
@@ -22,14 +21,20 @@ pub enum Feature {
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum Error {
-    /// General Parquet error.
-    General(String),
-    /// Error presented when trying to use a code branch that requires a feature.
-    FeatureNotActive(Feature, String),
     /// When the parquet file is known to be out of spec.
     OutOfSpec(String),
-    /// An error originating from a consumer or dependency
-    External(String, Arc<dyn std::error::Error + Send + Sync>),
+    /// Error presented when trying to use a code branch that requires activating a feature.
+    FeatureNotActive(Feature, String),
+    /// Error presented when trying to use a feature from parquet that is not yet supported
+    FeatureNotSupported(String),
+    /// When encoding, the user passed an invalid parameter
+    InvalidParameter(String),
+}
+
+impl Error {
+    pub(crate) fn oos<I: Into<String>>(message: I) -> Self {
+        Self::OutOfSpec(message.into())
+    }
 }
 
 impl std::error::Error for Error {}
@@ -37,8 +42,8 @@ impl std::error::Error for Error {}
 impl std::fmt::Display for Error {
     fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            Error::General(message) => {
-                write!(fmt, "{}", message)
+            Error::OutOfSpec(message) => {
+                write!(fmt, "File out of specification: {}", message)
             }
             Error::FeatureNotActive(feature, reason) => {
                 write!(
@@ -47,11 +52,11 @@ impl std::fmt::Display for Error {
                     feature, reason
                 )
             }
-            Error::OutOfSpec(message) => {
-                write!(fmt, "{}", message)
+            Error::FeatureNotSupported(reason) => {
+                write!(fmt, "Not yet supported: {}", reason)
             }
-            Error::External(message, err) => {
-                write!(fmt, "{}: {}", message, err)
+            Error::InvalidParameter(message) => {
+                write!(fmt, "Invalid parameter: {}", message)
             }
         }
     }
@@ -60,39 +65,39 @@ impl std::fmt::Display for Error {
 #[cfg(feature = "snappy")]
 impl From<snap::Error> for Error {
     fn from(e: snap::Error) -> Error {
-        Error::General(format!("underlying snap error: {}", e))
+        Error::OutOfSpec(format!("underlying snap error: {}", e))
     }
 }
 
 #[cfg(feature = "lz4_flex")]
 impl From<lz4_flex::block::DecompressError> for Error {
     fn from(e: lz4_flex::block::DecompressError) -> Error {
-        Error::General(format!("underlying lz4_flex error: {}", e))
+        Error::OutOfSpec(format!("underlying lz4_flex error: {}", e))
     }
 }
 
 #[cfg(feature = "lz4_flex")]
 impl From<lz4_flex::block::CompressError> for Error {
     fn from(e: lz4_flex::block::CompressError) -> Error {
-        Error::General(format!("underlying lz4_flex error: {}", e))
+        Error::OutOfSpec(format!("underlying lz4_flex error: {}", e))
     }
 }
 
 impl From<parquet_format_safe::thrift::Error> for Error {
     fn from(e: parquet_format_safe::thrift::Error) -> Error {
-        Error::General(format!("underlying thrift error: {}", e))
+        Error::OutOfSpec(format!("Invalid thrift: {}", e))
     }
 }
 
 impl From<std::io::Error> for Error {
     fn from(e: std::io::Error) -> Error {
-        Error::General(format!("underlying IO error: {}", e))
+        Error::OutOfSpec(format!("underlying IO error: {}", e))
     }
 }
 
 impl From<std::collections::TryReserveError> for Error {
     fn from(e: std::collections::TryReserveError) -> Error {
-        Error::General(format!("OOM: {}", e))
+        Error::OutOfSpec(format!("OOM: {}", e))
     }
 }
 
@@ -110,11 +115,3 @@ impl From<std::array::TryFromSliceError> for Error {
 
 /// A specialized `Result` for Parquet errors.
 pub type Result<T> = std::result::Result<T, Error>;
-
-macro_rules! general_err {
-    ($fmt:expr) => (Error::General($fmt.to_owned()));
-    ($fmt:expr, $($args:expr),*) => (Error::General(format!($fmt, $($args),*)));
-    ($e:expr, $fmt:expr) => (Error::General($fmt.to_owned(), $e));
-    ($e:ident, $fmt:expr, $($args:tt),*) => (
-        Error::General(&format!($fmt, $($args),*), $e));
-}

--- a/src/indexes/intervals.rs
+++ b/src/indexes/intervals.rs
@@ -32,9 +32,9 @@ pub fn compute_page_row_intervals(
 
     let last = (|| {
         let start: usize = locations.last().unwrap().first_row_index.try_into()?;
-        let length = num_rows.checked_sub(start).ok_or_else(|| {
-            Error::OutOfSpec("Page start cannot be smaller than the number of rows".to_string())
-        })?;
+        let length = num_rows
+            .checked_sub(start)
+            .ok_or_else(|| Error::oos("Page start cannot be smaller than the number of rows"))?;
         Result::<_, Error>::Ok(Interval::new(start, length))
     })();
 
@@ -46,11 +46,7 @@ pub fn compute_page_row_intervals(
             let length = x[1]
                 .first_row_index
                 .checked_sub(x[0].first_row_index)
-                .ok_or_else(|| {
-                    Error::OutOfSpec(
-                        "Page start cannot be smaller than the number of rows".to_string(),
-                    )
-                })?
+                .ok_or_else(|| Error::oos("Page start cannot be smaller than the number of rows"))?
                 .try_into()?;
 
             Ok(Interval::new(start, length))

--- a/src/metadata/column_chunk_metadata.rs
+++ b/src/metadata/column_chunk_metadata.rs
@@ -143,9 +143,7 @@ impl ColumnChunkMetaData {
 
             let _: Compression = meta.codec.try_into()?;
         } else {
-            return Err(Error::OutOfSpec(
-                "Column chunk requires metdata".to_string(),
-            ));
+            return Err(Error::oos("Column chunk requires metdata"));
         }
 
         Ok(Self {

--- a/src/metadata/row_metadata.rs
+++ b/src/metadata/row_metadata.rs
@@ -57,7 +57,7 @@ impl RowGroupMetaData {
         rg: RowGroup,
     ) -> Result<RowGroupMetaData> {
         if schema_descr.columns().len() != rg.columns.len() {
-            return Err(Error::OutOfSpec(format!("The number of columns in the row group ({}) must be equal to the number of columns in the schema ({})", rg.columns.len(), schema_descr.columns().len())));
+            return Err(Error::oos(format!("The number of columns in the row group ({}) must be equal to the number of columns in the schema ({})", rg.columns.len(), schema_descr.columns().len())));
         }
         let total_byte_size = rg.total_byte_size.try_into()?;
         let num_rows = rg.num_rows.try_into()?;

--- a/src/metadata/schema_descriptor.rs
+++ b/src/metadata/schema_descriptor.rs
@@ -74,9 +74,7 @@ impl SchemaDescriptor {
             ParquetType::GroupType {
                 field_info, fields, ..
             } => Ok(Self::new(field_info.name, fields)),
-            _ => Err(Error::OutOfSpec(
-                "The parquet schema MUST be a group type".to_string(),
-            )),
+            _ => Err(Error::oos("The parquet schema MUST be a group type")),
         }
     }
 

--- a/src/page/mod.rs
+++ b/src/page/mod.rs
@@ -358,22 +358,17 @@ pub fn split_buffer_v1(
 ) -> Result<(&[u8], &[u8], &[u8])> {
     let (rep, buffer) = if has_rep {
         let level_buffer_length = get_length(buffer).ok_or_else(|| {
-            Error::OutOfSpec(
-                "The number of bytes declared in v1 rep levels is higher than the page size"
-                    .to_string(),
-            )
+            Error::oos("The number of bytes declared in v1 rep levels is higher than the page size")
         })?;
         (
             buffer.get(4..4 + level_buffer_length).ok_or_else(|| {
-                Error::OutOfSpec(
-                    "The number of bytes declared in v1 rep levels is higher than the page size"
-                        .to_string(),
+                Error::oos(
+                    "The number of bytes declared in v1 rep levels is higher than the page size",
                 )
             })?,
             buffer.get(4 + level_buffer_length..).ok_or_else(|| {
-                Error::OutOfSpec(
-                    "The number of bytes declared in v1 rep levels is higher than the page size"
-                        .to_string(),
+                Error::oos(
+                    "The number of bytes declared in v1 rep levels is higher than the page size",
                 )
             })?,
         )
@@ -383,22 +378,17 @@ pub fn split_buffer_v1(
 
     let (def, buffer) = if has_def {
         let level_buffer_length = get_length(buffer).ok_or_else(|| {
-            Error::OutOfSpec(
-                "The number of bytes declared in v1 rep levels is higher than the page size"
-                    .to_string(),
-            )
+            Error::oos("The number of bytes declared in v1 rep levels is higher than the page size")
         })?;
         (
             buffer.get(4..4 + level_buffer_length).ok_or_else(|| {
-                Error::OutOfSpec(
-                    "The number of bytes declared in v1 def levels is higher than the page size"
-                        .to_string(),
+                Error::oos(
+                    "The number of bytes declared in v1 def levels is higher than the page size",
                 )
             })?,
             buffer.get(4 + level_buffer_length..).ok_or_else(|| {
-                Error::OutOfSpec(
-                    "The number of bytes declared in v1 def levels is higher than the page size"
-                        .to_string(),
+                Error::oos(
+                    "The number of bytes declared in v1 def levels is higher than the page size",
                 )
             })?,
         )

--- a/src/parquet_bridge.rs
+++ b/src/parquet_bridge.rs
@@ -29,7 +29,7 @@ impl TryFrom<FieldRepetitionType> for Repetition {
             FieldRepetitionType::REQUIRED => Repetition::Required,
             FieldRepetitionType::OPTIONAL => Repetition::Optional,
             FieldRepetitionType::REPEATED => Repetition::Repeated,
-            _ => return Err(Error::OutOfSpec("Thrift out of range".to_string())),
+            _ => return Err(Error::oos("Thrift out of range")),
         })
     }
 }
@@ -69,7 +69,7 @@ impl TryFrom<CompressionCodec> for Compression {
             CompressionCodec::LZ4 => Compression::Lz4,
             CompressionCodec::ZSTD => Compression::Zstd,
             CompressionCodec::LZ4_RAW => Compression::Lz4Raw,
-            _ => return Err(Error::OutOfSpec("Thrift out of range".to_string())),
+            _ => return Err(Error::oos("Thrift out of range")),
         })
     }
 }
@@ -145,7 +145,7 @@ pub(crate) trait CompressionLevel<T: std::fmt::Display + std::cmp::PartialOrd> {
         if compression_range.contains(&level) {
             Ok(())
         } else {
-            Err(Error::General(format!(
+            Err(Error::InvalidParameter(format!(
                 "valid compression range {}..={} exceeded.",
                 compression_range.start(),
                 compression_range.end()
@@ -275,7 +275,7 @@ impl TryFrom<ParquetPageType> for PageType {
             ParquetPageType::DATA_PAGE => PageType::DataPage,
             ParquetPageType::DATA_PAGE_V2 => PageType::DataPageV2,
             ParquetPageType::DICTIONARY_PAGE => PageType::DictionaryPage,
-            _ => return Err(Error::OutOfSpec("Thrift out of range".to_string())),
+            _ => return Err(Error::oos("Thrift out of range")),
         })
     }
 }
@@ -346,7 +346,7 @@ impl TryFrom<ParquetEncoding> for Encoding {
             ParquetEncoding::DELTA_BYTE_ARRAY => Encoding::DeltaByteArray,
             ParquetEncoding::RLE_DICTIONARY => Encoding::RleDictionary,
             ParquetEncoding::BYTE_STREAM_SPLIT => Encoding::ByteStreamSplit,
-            _ => return Err(Error::OutOfSpec("Thrift out of range".to_string())),
+            _ => return Err(Error::oos("Thrift out of range")),
         })
     }
 }
@@ -390,11 +390,7 @@ impl TryFrom<ParquetBoundaryOrder> for BoundaryOrder {
             ParquetBoundaryOrder::UNORDERED => BoundaryOrder::Unordered,
             ParquetBoundaryOrder::ASCENDING => BoundaryOrder::Ascending,
             ParquetBoundaryOrder::DESCENDING => BoundaryOrder::Descending,
-            _ => {
-                return Err(Error::OutOfSpec(
-                    "BoundaryOrder Thrift value out of range".to_string(),
-                ))
-            }
+            _ => return Err(Error::oos("BoundaryOrder Thrift value out of range")),
         })
     }
 }
@@ -579,11 +575,7 @@ impl TryFrom<ParquetLogicalType> for PrimitiveLogicalType {
             ParquetLogicalType::JSON(_) => PrimitiveLogicalType::Json,
             ParquetLogicalType::BSON(_) => PrimitiveLogicalType::Bson,
             ParquetLogicalType::UUID(_) => PrimitiveLogicalType::Uuid,
-            _ => {
-                return Err(Error::OutOfSpec(
-                    "LogicalType value out of range".to_string(),
-                ))
-            }
+            _ => return Err(Error::oos("LogicalType value out of range")),
         })
     }
 }
@@ -595,11 +587,7 @@ impl TryFrom<ParquetLogicalType> for GroupLogicalType {
         Ok(match type_ {
             ParquetLogicalType::LIST(_) => GroupLogicalType::List,
             ParquetLogicalType::MAP(_) => GroupLogicalType::Map,
-            _ => {
-                return Err(Error::OutOfSpec(
-                    "LogicalType value out of range".to_string(),
-                ))
-            }
+            _ => return Err(Error::oos("LogicalType value out of range")),
         })
     }
 }

--- a/src/read/indexes/read.rs
+++ b/src/read/indexes/read.rs
@@ -37,7 +37,7 @@ fn prepare_read<F: Fn(&ColumnChunk) -> Option<i64>, G: Fn(&ColumnChunk) -> Optio
         .map(|x| get_length(x.column_chunk()))
         .map(|maybe_length| {
             let index_length = maybe_length.ok_or_else(|| {
-                Error::OutOfSpec("The column length must exist if column offset exists".to_string())
+                Error::oos("The column length must exist if column offset exists")
             })?;
 
             Ok(index_length.try_into()?)

--- a/src/read/metadata.rs
+++ b/src/read/metadata.rs
@@ -36,8 +36,8 @@ pub fn read_metadata<R: Read + Seek>(reader: &mut R) -> Result<FileMetaData> {
     // check file is large enough to hold footer
     let file_size = stream_len(reader)?;
     if file_size < HEADER_SIZE + FOOTER_SIZE {
-        return Err(Error::OutOfSpec(
-            "A parquet file must containt a header and footer with at least 12 bytes".to_string(),
+        return Err(Error::oos(
+            "A parquet file must containt a header and footer with at least 12 bytes",
         ));
     }
 
@@ -53,7 +53,7 @@ pub fn read_metadata<R: Read + Seek>(reader: &mut R) -> Result<FileMetaData> {
 
     // check this is indeed a parquet file
     if buffer[default_end_len - 4..] != PARQUET_MAGIC {
-        return Err(Error::OutOfSpec("The file must end with PAR1".to_string()));
+        return Err(Error::oos("The file must end with PAR1"));
     }
 
     let metadata_len = metadata_len(&buffer, default_end_len);
@@ -62,8 +62,8 @@ pub fn read_metadata<R: Read + Seek>(reader: &mut R) -> Result<FileMetaData> {
 
     let footer_len = FOOTER_SIZE + metadata_len;
     if footer_len > file_size {
-        return Err(Error::OutOfSpec(
-            "The footer size must be smaller or equal to the file's size".to_string(),
+        return Err(Error::oos(
+            "The footer size must be smaller or equal to the file's size",
         ));
     }
 

--- a/src/read/page/indexed_reader.rs
+++ b/src/read/page/indexed_reader.rs
@@ -85,8 +85,8 @@ fn read_dict_page<R: Read + Seek>(
     if let CompressedPage::Dict(page) = page {
         Ok(page)
     } else {
-        Err(Error::OutOfSpec(
-            "The first page is not a dictionary page but it should".to_string(),
+        Err(Error::oos(
+            "The first page is not a dictionary page but it should",
         ))
     }
 }

--- a/src/read/page/reader.rs
+++ b/src/read/page/reader.rs
@@ -229,9 +229,8 @@ pub(super) fn finish_page(
     match type_ {
         PageType::DictionaryPage => {
             let dict_header = page_header.dictionary_page_header.as_ref().ok_or_else(|| {
-                Error::OutOfSpec(
-                    "The page header type is a dictionary page but the dictionary header is empty"
-                        .to_string(),
+                Error::oos(
+                    "The page header type is a dictionary page but the dictionary header is empty",
                 )
             })?;
             let is_sorted = dict_header.is_sorted.unwrap_or(false);
@@ -249,10 +248,7 @@ pub(super) fn finish_page(
         }
         PageType::DataPage => {
             let header = page_header.data_page_header.ok_or_else(|| {
-                Error::OutOfSpec(
-                    "The page header type is a v1 data page but the v1 data header is empty"
-                        .to_string(),
-                )
+                Error::oos("The page header type is a v1 data page but the v1 data header is empty")
             })?;
 
             Ok(CompressedPage::Data(CompressedDataPage::new_read(
@@ -266,10 +262,7 @@ pub(super) fn finish_page(
         }
         PageType::DataPageV2 => {
             let header = page_header.data_page_header_v2.ok_or_else(|| {
-                Error::OutOfSpec(
-                    "The page header type is a v2 data page but the v2 data header is empty"
-                        .to_string(),
-                )
+                Error::oos("The page header type is a v2 data page but the v2 data header is empty")
             })?;
 
             Ok(CompressedPage::Data(CompressedDataPage::new_read(
@@ -289,9 +282,7 @@ pub(super) fn get_page_header(header: &ParquetPageHeader) -> Result<Option<DataP
     Ok(match type_ {
         PageType::DataPage => {
             let header = header.data_page_header.clone().ok_or_else(|| {
-                Error::OutOfSpec(
-                    "The page header type is a v1 data page but the v1 header is empty".to_string(),
-                )
+                Error::oos("The page header type is a v1 data page but the v1 header is empty")
             })?;
             let _: Encoding = header.encoding.try_into()?;
             let _: Encoding = header.repetition_level_encoding.try_into()?;
@@ -301,9 +292,7 @@ pub(super) fn get_page_header(header: &ParquetPageHeader) -> Result<Option<DataP
         }
         PageType::DataPageV2 => {
             let header = header.data_page_header_v2.clone().ok_or_else(|| {
-                Error::OutOfSpec(
-                    "The page header type is a v1 data page but the v1 header is empty".to_string(),
-                )
+                Error::oos("The page header type is a v1 data page but the v1 header is empty")
             })?;
             let _: Encoding = header.encoding.try_into()?;
             Some(DataPageHeader::V2(header))

--- a/src/read/stream.rs
+++ b/src/read/stream.rs
@@ -29,8 +29,8 @@ pub async fn read_metadata<R: AsyncRead + AsyncSeek + Send + std::marker::Unpin>
     let file_size = stream_len(reader).await?;
 
     if file_size < HEADER_SIZE + FOOTER_SIZE {
-        return Err(general_err!(
-            "Invalid Parquet file. Size is smaller than header + footer"
+        return Err(Error::oos(
+            "A parquet file must containt a header and footer with at least 12 bytes",
         ));
     }
 
@@ -49,9 +49,7 @@ pub async fn read_metadata<R: AsyncRead + AsyncSeek + Send + std::marker::Unpin>
 
     // check this is indeed a parquet file
     if buffer[default_end_len - 4..] != PARQUET_MAGIC {
-        return Err(Error::OutOfSpec(
-            "Invalid Parquet file. Corrupt footer".to_string(),
-        ));
+        return Err(Error::oos("Invalid Parquet file. Corrupt footer"));
     }
 
     let metadata_len = metadata_len(&buffer, default_end_len);
@@ -59,8 +57,8 @@ pub async fn read_metadata<R: AsyncRead + AsyncSeek + Send + std::marker::Unpin>
 
     let footer_len = FOOTER_SIZE + metadata_len;
     if footer_len > file_size {
-        return Err(Error::OutOfSpec(
-            "The footer size must be smaller or equal to the file's size".to_string(),
+        return Err(Error::oos(
+            "The footer size must be smaller or equal to the file's size",
         ));
     }
 

--- a/src/schema/types/converted_type.rs
+++ b/src/schema/types/converted_type.rs
@@ -113,7 +113,7 @@ impl TryFrom<(ConvertedType, Option<(i32, i32)>)> for PrimitiveConvertedType {
                 if let Some((precision, scale)) = maybe_decimal {
                     Decimal(precision.try_into()?, scale.try_into()?)
                 } else {
-                    return Err(general_err!("Decimal requires a precision and scale"));
+                    return Err(Error::oos("Decimal requires a precision and scale"));
                 }
             }
             ConvertedType::DATE => Date,
@@ -133,10 +133,10 @@ impl TryFrom<(ConvertedType, Option<(i32, i32)>)> for PrimitiveConvertedType {
             ConvertedType::BSON => Bson,
             ConvertedType::INTERVAL => Interval,
             _ => {
-                return Err(general_err!(
+                return Err(Error::oos(format!(
                     "Converted type \"{:?}\" cannot be applied to a primitive type",
                     ty
-                ))
+                )))
             }
         })
     }
@@ -150,11 +150,7 @@ impl TryFrom<ConvertedType> for GroupConvertedType {
             ConvertedType::LIST => GroupConvertedType::List,
             ConvertedType::MAP => GroupConvertedType::Map,
             ConvertedType::MAP_KEY_VALUE => GroupConvertedType::MapKeyValue,
-            _ => {
-                return Err(Error::OutOfSpec(
-                    "LogicalType value out of range".to_string(),
-                ))
-            }
+            _ => return Err(Error::oos("LogicalType value out of range")),
         })
     }
 }

--- a/src/schema/types/physical_type.rs
+++ b/src/schema/types/physical_type.rs
@@ -29,10 +29,10 @@ impl TryFrom<(Type, Option<i32>)> for PhysicalType {
             Type::BYTE_ARRAY => PhysicalType::ByteArray,
             Type::FIXED_LEN_BYTE_ARRAY => {
                 let length = length
-                    .ok_or_else(|| general_err!("Length must be defined for FixedLenByteArray"))?;
+                    .ok_or_else(|| Error::oos("Length must be defined for FixedLenByteArray"))?;
                 PhysicalType::FixedLenByteArray(length.try_into()?)
             }
-            _ => return Err(general_err!("Type out of length")),
+            _ => return Err(Error::oos("Unknown type")),
         })
     }
 }

--- a/src/statistics/boolean.rs
+++ b/src/statistics/boolean.rs
@@ -33,15 +33,15 @@ impl Statistics for BooleanStatistics {
 pub fn read(v: &ParquetStatistics) -> Result<Arc<dyn Statistics>> {
     if let Some(ref v) = v.max_value {
         if v.len() != std::mem::size_of::<bool>() {
-            return Err(Error::OutOfSpec(
-                "The max_value of statistics MUST be plain encoded".to_string(),
+            return Err(Error::oos(
+                "The max_value of statistics MUST be plain encoded",
             ));
         }
     };
     if let Some(ref v) = v.min_value {
         if v.len() != std::mem::size_of::<bool>() {
-            return Err(Error::OutOfSpec(
-                "The min_value of statistics MUST be plain encoded".to_string(),
+            return Err(Error::oos(
+                "The min_value of statistics MUST be plain encoded",
             ));
         }
     };

--- a/src/statistics/fixed_len_binary.rs
+++ b/src/statistics/fixed_len_binary.rs
@@ -38,15 +38,15 @@ pub fn read(
 ) -> Result<Arc<dyn Statistics>> {
     if let Some(ref v) = v.max_value {
         if v.len() != size {
-            return Err(Error::OutOfSpec(
-                "The max_value of statistics MUST be plain encoded".to_string(),
+            return Err(Error::oos(
+                "The max_value of statistics MUST be plain encoded",
             ));
         }
     };
     if let Some(ref v) = v.min_value {
         if v.len() != size {
-            return Err(Error::OutOfSpec(
-                "The min_value of statistics MUST be plain encoded".to_string(),
+            return Err(Error::oos(
+                "The min_value of statistics MUST be plain encoded",
             ));
         }
     };

--- a/src/statistics/primitive.rs
+++ b/src/statistics/primitive.rs
@@ -36,15 +36,15 @@ pub fn read<T: types::NativeType>(
 ) -> Result<Arc<dyn Statistics>> {
     if let Some(ref v) = v.max_value {
         if v.len() != std::mem::size_of::<T>() {
-            return Err(Error::OutOfSpec(
-                "The max_value of statistics MUST be plain encoded".to_string(),
+            return Err(Error::oos(
+                "The max_value of statistics MUST be plain encoded",
             ));
         }
     };
     if let Some(ref v) = v.min_value {
         if v.len() != std::mem::size_of::<T>() {
-            return Err(Error::OutOfSpec(
-                "The min_value of statistics MUST be plain encoded".to_string(),
+            return Err(Error::oos(
+                "The min_value of statistics MUST be plain encoded",
             ));
         }
     };

--- a/src/write/column_chunk.rs
+++ b/src/write/column_chunk.rs
@@ -112,8 +112,8 @@ fn build_column_chunk(
         .map(|spec| spec.compression)
         .collect::<HashSet<_>>();
     if compression.len() > 1 {
-        return Err(crate::error::Error::OutOfSpec(
-            "All pages within a column chunk must be compressed with the same codec".to_string(),
+        return Err(crate::error::Error::oos(
+            "All pages within a column chunk must be compressed with the same codec",
         ));
     }
     let compression = compression

--- a/src/write/file.rs
+++ b/src/write/file.rs
@@ -129,7 +129,9 @@ impl<W: Write> FileWriter<W> {
             self.state = State::Started;
             Ok(())
         } else {
-            Err(Error::General("Start cannot be called twice".to_string()))
+            Err(Error::InvalidParameter(
+                "Start cannot be called twice".to_string(),
+            ))
         }
     }
 
@@ -166,7 +168,9 @@ impl<W: Write> FileWriter<W> {
         }
 
         if self.state != State::Started {
-            return Err(Error::General("End cannot be called twice".to_string()));
+            return Err(Error::InvalidParameter(
+                "End cannot be called twice".to_string(),
+            ));
         }
         // compute file stats
         let num_rows = self.row_groups.iter().map(|group| group.num_rows).sum();

--- a/src/write/indexes/serialize.rs
+++ b/src/write/indexes/serialize.rs
@@ -22,9 +22,9 @@ pub fn serialize_column_index(pages: &[PageWriteSpec]) -> Result<ColumnIndex> {
             if let Some(stats) = &spec.statistics {
                 let stats = serialize_statistics(stats.as_ref());
 
-                let null_count = stats.null_count.ok_or_else(|| {
-                    Error::OutOfSpec("null count of a page is required".to_string())
-                })?;
+                let null_count = stats
+                    .null_count
+                    .ok_or_else(|| Error::oos("null count of a page is required"))?;
 
                 null_counts.push(null_count);
                 if null_count as usize == spec.num_values {
@@ -32,19 +32,23 @@ pub fn serialize_column_index(pages: &[PageWriteSpec]) -> Result<ColumnIndex> {
                     max_values.push(vec![0]);
                     null_pages.push(true)
                 } else {
-                    min_values.push(stats.min_value.ok_or_else(|| {
-                        Error::OutOfSpec("min value of a page is required".to_string())
-                    })?);
-                    max_values.push(stats.max_value.ok_or_else(|| {
-                        Error::OutOfSpec("max value of a page is required".to_string())
-                    })?);
+                    min_values.push(
+                        stats
+                            .min_value
+                            .ok_or_else(|| Error::oos("min value of a page is required"))?,
+                    );
+                    max_values.push(
+                        stats
+                            .max_value
+                            .ok_or_else(|| Error::oos("max value of a page is required"))?,
+                    );
                     null_pages.push(false)
                 };
 
                 Result::Ok(())
             } else {
-                Err(Error::OutOfSpec(
-                    "options were set to write statistics but some pages miss them".to_string(),
+                Err(Error::oos(
+                    "options were set to write statistics but some pages miss them",
                 ))
             }
         })?;
@@ -69,9 +73,8 @@ pub fn serialize_offset_index(pages: &[PageWriteSpec]) -> Result<OffsetIndex> {
                 first_row_index,
             };
             let num_rows = spec.num_rows.ok_or_else(|| {
-                Error::OutOfSpec(
-                    "options were set to write statistics but some data pages miss number of rows"
-                        .to_string(),
+                Error::oos(
+                    "options were set to write statistics but some data pages miss number of rows",
                 )
             })?;
             first_row_index += num_rows as i64;

--- a/src/write/page.rs
+++ b/src/write/page.rs
@@ -23,14 +23,14 @@ pub(crate) fn is_data_page(page: &PageWriteSpec) -> bool {
 
 fn maybe_bytes(uncompressed: usize, compressed: usize) -> Result<(i32, i32)> {
     let uncompressed_page_size: i32 = uncompressed.try_into().map_err(|_| {
-        Error::OutOfSpec(format!(
+        Error::oos(format!(
             "A page can only contain i32::MAX uncompressed bytes. This one contains {}",
             uncompressed
         ))
     })?;
 
     let compressed_page_size: i32 = compressed.try_into().map_err(|_| {
-        Error::OutOfSpec(format!(
+        Error::oos(format!(
             "A page can only contain i32::MAX compressed bytes. This one contains {}",
             compressed
         ))
@@ -175,7 +175,7 @@ fn assemble_dict_page_header(page: &CompressedDictPage) -> Result<ParquetPageHea
         maybe_bytes(page.uncompressed_page_size, page.buffer.len())?;
 
     let num_values: i32 = page.num_values.try_into().map_err(|_| {
-        Error::OutOfSpec(format!(
+        Error::oos(format!(
             "A dictionary page can only contain i32::MAX items. This one contains {}",
             page.num_values
         ))

--- a/src/write/row_group.rs
+++ b/src/write/row_group.rs
@@ -66,9 +66,7 @@ fn compute_num_rows(columns: &[(ColumnChunk, Vec<PageWriteSpec>)]) -> Result<i64
                 .filter(|x| is_data_page(x))
                 .try_for_each(|spec| {
                     num_rows += spec.num_rows.ok_or_else(|| {
-                        Error::OutOfSpec(
-                            "All data pages must declare the number of rows on it".to_string(),
-                        )
+                        Error::oos("All data pages must declare the number of rows on it")
                     })? as i64;
                     Result::Ok(())
                 })?;

--- a/src/write/statistics.rs
+++ b/src/write/statistics.rs
@@ -43,9 +43,7 @@ pub fn reduce(stats: &[&Option<Arc<dyn Statistics>>]) -> Result<Option<Arc<dyn S
         .skip(1)
         .all(|x| x.physical_type() == stats[0].physical_type());
     if !same_type {
-        return Err(Error::OutOfSpec(
-            "The statistics do not have the same data_type".to_string(),
-        ));
+        return Err(Error::oos("The statistics do not have the same data_type"));
     };
     Ok(match stats[0].physical_type() {
         PhysicalType::Boolean => {

--- a/src/write/stream.rs
+++ b/src/write/stream.rs
@@ -106,7 +106,9 @@ impl<W: AsyncWrite + Unpin + Send> FileStreamer<W> {
             self.state = State::Started;
             Ok(())
         } else {
-            Err(Error::General("Start cannot be called twice".to_string()))
+            Err(Error::InvalidParameter(
+                "Start cannot be called twice".to_string(),
+            ))
         }
     }
 
@@ -143,7 +145,9 @@ impl<W: AsyncWrite + Unpin + Send> FileStreamer<W> {
         }
 
         if self.state != State::Started {
-            return Err(Error::General("End cannot be called twice".to_string()));
+            return Err(Error::InvalidParameter(
+                "End cannot be called twice".to_string(),
+            ));
         }
         // compute file stats
         let num_rows = self.row_groups.iter().map(|group| group.num_rows).sum();

--- a/tests/it/read/primitive.rs
+++ b/tests/it/read/primitive.rs
@@ -72,8 +72,8 @@ impl<'a, T: NativeType> PageState<'a, T> {
                     );
                     Ok(Self::Filtered(FilteredPageState::Required(values)))
                 }
-                _ => Err(Error::General(format!(
-                    "Viewing page for encoding {:?} for native type {} not supported",
+                _ => Err(Error::FeatureNotSupported(format!(
+                    "Viewing page for encoding {:?} for native type {}",
                     page.encoding(),
                     std::any::type_name::<T>()
                 ))),


### PR DESCRIPTION
Replaced `Error::General` and `Error::External` by `Error::InvalidParameter` and `Error::FeatureNotSupported` - `General` is not very insigthful and is not something the user can do much about.

Audited code for returning errors and adjusted them accordingly.
