### PR TITLE
Updating parquet tools

### DIFF
--- a/parquet-tools/Cargo.toml
+++ b/parquet-tools/Cargo.toml
@@ -15,5 +15,5 @@ name = "parquet_tools"
 path = "src/main.rs"
 
 [dependencies]
-parquet2 = { version = "0.14", path = "../" }
-clap = {version = "2.33", features = ["yaml"]}
+parquet2 = { version = "0.15", path = "../" }
+clap = {version = "3.2.17", features = ["yaml"]}


### PR DESCRIPTION
Updating parquet tools after the `dictionary_page` was removed from `CompressedDataPage`. Draft PR to follow up Issue #177 