### PR TITLE
Removed `EncodedPage` 

### DIFF
--- a/src/page/mod.rs
+++ b/src/page/mod.rs
@@ -230,7 +230,9 @@ impl DataPage {
 #[derive(Debug)]
 #[allow(clippy::large_enum_variant)]
 pub enum Page {
+    /// A [`DataPage`]
     Data(DataPage),
+    /// A [`DictPage`]
     Dict(DictPage),
 }
 
@@ -241,15 +243,6 @@ impl Page {
             Self::Dict(page) => &mut page.buffer,
         }
     }
-}
-
-/// A [`EncodedPage`] is an uncompressed, encoded representation of a Parquet page. It may hold actual data
-/// and thus cloning it may be expensive.
-#[derive(Debug)]
-#[allow(clippy::large_enum_variant)]
-pub enum EncodedPage {
-    Data(DataPage),
-    Dict(DictPage),
 }
 
 /// A [`CompressedPage`] is a compressed, encoded representation of a Parquet page. It holds actual data

--- a/src/write/compression.rs
+++ b/src/write/compression.rs
@@ -4,7 +4,7 @@ use crate::page::{CompressedDictPage, CompressedPage, DataPageHeader, DictPage};
 use crate::FallibleStreamingIterator;
 use crate::{
     compression,
-    page::{CompressedDataPage, DataPage, EncodedPage},
+    page::{CompressedDataPage, DataPage, Page},
 };
 
 /// Compresses a [`DataPage`] into a [`CompressedDataPage`].
@@ -83,30 +83,30 @@ fn compress_dict(
 /// # Errors
 /// Errors if the compressor fails
 pub fn compress(
-    page: EncodedPage,
+    page: Page,
     compressed_buffer: Vec<u8>,
     compression: CompressionOptions,
 ) -> Result<CompressedPage> {
     match page {
-        EncodedPage::Data(page) => {
+        Page::Data(page) => {
             compress_data(page, compressed_buffer, compression).map(CompressedPage::Data)
         }
-        EncodedPage::Dict(page) => {
+        Page::Dict(page) => {
             compress_dict(page, compressed_buffer, compression).map(CompressedPage::Dict)
         }
     }
 }
 
-/// A [`FallibleStreamingIterator`] that consumes [`EncodedPage`] and yields [`CompressedPage`]
+/// A [`FallibleStreamingIterator`] that consumes [`Page`] and yields [`CompressedPage`]
 /// holding a reusable buffer ([`Vec<u8>`]) for compression.
-pub struct Compressor<I: Iterator<Item = Result<EncodedPage>>> {
+pub struct Compressor<I: Iterator<Item = Result<Page>>> {
     iter: I,
     compression: CompressionOptions,
     buffer: Vec<u8>,
     current: Option<CompressedPage>,
 }
 
-impl<I: Iterator<Item = Result<EncodedPage>>> Compressor<I> {
+impl<I: Iterator<Item = Result<Page>>> Compressor<I> {
     /// Creates a new [`Compressor`]
     pub fn new(iter: I, compression: CompressionOptions, buffer: Vec<u8>) -> Self {
         Self {
@@ -134,7 +134,7 @@ impl<I: Iterator<Item = Result<EncodedPage>>> Compressor<I> {
     }
 }
 
-impl<I: Iterator<Item = Result<EncodedPage>>> FallibleStreamingIterator for Compressor<I> {
+impl<I: Iterator<Item = Result<Page>>> FallibleStreamingIterator for Compressor<I> {
     type Item = CompressedPage;
     type Error = Error;
 

--- a/tests/it/write/binary.rs
+++ b/tests/it/write/binary.rs
@@ -1,7 +1,7 @@
 use parquet2::{
     encoding::Encoding,
     metadata::Descriptor,
-    page::{DataPage, DataPageHeader, DataPageHeaderV1, EncodedPage},
+    page::{DataPage, DataPageHeader, DataPageHeaderV1, Page},
     statistics::{serialize_statistics, BinaryStatistics, Statistics},
     types::ord_binary,
     write::WriteOptions,
@@ -45,7 +45,7 @@ pub fn array_to_page_v1(
     array: &[Option<Vec<u8>>],
     options: &WriteOptions,
     descriptor: &Descriptor,
-) -> Result<EncodedPage> {
+) -> Result<Page> {
     let (values, mut buffer) = unzip_option(array)?;
 
     buffer.extend_from_slice(&values);
@@ -79,7 +79,7 @@ pub fn array_to_page_v1(
         statistics,
     };
 
-    Ok(EncodedPage::Data(DataPage::new(
+    Ok(Page::Data(DataPage::new(
         DataPageHeader::V1(header),
         buffer,
         descriptor.clone(),

--- a/tests/it/write/mod.rs
+++ b/tests/it/write/mod.rs
@@ -15,7 +15,7 @@ use parquet2::statistics::Statistics;
 #[cfg(feature = "async")]
 use parquet2::write::FileStreamer;
 use parquet2::write::{Compressor, DynIter, DynStreamingIterator, FileWriter, Version};
-use parquet2::{metadata::Descriptor, page::EncodedPage, write::WriteOptions};
+use parquet2::{metadata::Descriptor, page::Page, write::WriteOptions};
 
 use super::Array;
 use super::{alltypes_plain, alltypes_statistics};
@@ -25,7 +25,7 @@ pub fn array_to_page(
     array: &Array,
     options: &WriteOptions,
     descriptor: &Descriptor,
-) -> Result<EncodedPage> {
+) -> Result<Page> {
     // using plain encoding format
     match array {
         Array::Int32(array) => primitive::array_to_page_v1(array, options, descriptor),

--- a/tests/it/write/primitive.rs
+++ b/tests/it/write/primitive.rs
@@ -1,7 +1,7 @@
 use parquet2::{
     encoding::Encoding,
     metadata::Descriptor,
-    page::{DataPage, DataPageHeader, DataPageHeaderV1, EncodedPage},
+    page::{DataPage, DataPageHeader, DataPageHeaderV1, Page},
     statistics::{serialize_statistics, PrimitiveStatistics, Statistics},
     types::NativeType,
     write::WriteOptions,
@@ -44,7 +44,7 @@ pub fn array_to_page_v1<T: NativeType>(
     array: &[Option<T>],
     options: &WriteOptions,
     descriptor: &Descriptor,
-) -> Result<EncodedPage> {
+) -> Result<Page> {
     let (values, mut buffer) = unzip_option(array)?;
 
     buffer.extend_from_slice(&values);
@@ -70,7 +70,7 @@ pub fn array_to_page_v1<T: NativeType>(
         statistics,
     };
 
-    Ok(EncodedPage::Data(DataPage::new(
+    Ok(Page::Data(DataPage::new(
         DataPageHeader::V1(header),
         buffer,
         descriptor.clone(),


### PR DESCRIPTION
This was an unfortunate leftover from the previous simplification - `Page` is structurally the same and was intended to replace `EncodedPage` 