### PR TITLE
Improved hybrid rle decoding performance ~-40%

### DIFF
--- a/src/encoding/hybrid_rle/mod.rs
+++ b/src/encoding/hybrid_rle/mod.rs
@@ -25,6 +25,9 @@ enum State<'a> {
     None,
     Bitpacked(bitpacked::Decoder<'a, u32>),
     Rle(std::iter::Take<std::iter::Repeat<u32>>),
+    // Add a special branch for a single value to
+    // adhere to the strong law of small numbers.
+    Single(u32),
 }
 
 /// [`Iterator`] of [`u32`] from a byte slice of Hybrid-RLE encoded values
@@ -50,7 +53,11 @@ fn read_next<'a, 'b>(decoder: &'b mut Decoder<'a>, remaining: usize) -> Result<S
                 .enumerate()
                 .for_each(|(i, byte)| bytes[i] = *byte);
             let value = u32::from_le_bytes(bytes);
-            State::Rle(std::iter::repeat(value).take(additional))
+            if additional == 1 {
+                State::Single(value)
+            } else {
+                State::Rle(std::iter::repeat(value).take(additional))
+            }
         }
         None => State::None,
     })
@@ -78,6 +85,7 @@ impl<'a> Iterator for HybridRleDecoder<'a> {
             return None;
         };
         let result = match &mut self.state {
+            State::Single(i) => Some(*i),
             State::Bitpacked(decoder) => decoder.next(),
             State::Rle(iter) => iter.next(),
             State::None => Some(0),


### PR DESCRIPTION
Due to the law of small numbers most values are 1 and therefore extending with a `std::iter::repeat(value).take(1)` is a large overhead. This adds an extra `State` branch for the single value case.

This reduces reading a single column with uuid strings by ca 40% on my real world dataset.

I also have removed a redundant `Error` from the types. There are more of those redundant errors that I want to follow up in a later PR.