### PR TITLE
Add `PageInspector` to allow inspecting page info during page iteration.

### DIFF
--- a/src/encoding/delta_byte_array/encoder.rs
+++ b/src/encoding/delta_byte_array/encoder.rs
@@ -17,7 +17,7 @@ pub fn encode<'a, I: Iterator<Item = &'a [u8]> + Clone>(iterator: I, buffer: &mu
                 // find first difference
                 .find_map(|(length, (lhs, rhs))| {
                     println!("{lhs} {rhs}");
-                    (lhs != rhs).then(|| length)
+                    (lhs != rhs).then_some(length)
                 })
                 .unwrap_or(previous.len());
             previous = item;

--- a/src/encoding/hybrid_rle/encoder.rs
+++ b/src/encoding/hybrid_rle/encoder.rs
@@ -16,7 +16,7 @@ pub fn encode_u32<W: Write, I: Iterator<Item = u32>>(
     let length = iterator.size_hint().1.unwrap();
 
     // write the length + indicator
-    let mut header = ceil8(length as usize) as u64;
+    let mut header = ceil8(length) as u64;
     header <<= 1;
     header |= 1; // it is bitpacked => first bit is set
     let mut container = [0; 10];
@@ -57,7 +57,7 @@ fn bitpacked_encode_u32<W: Write, I: Iterator<Item = u32>>(
     }
 
     if remainder != 0 {
-        let compressed_remainder_size = ceil8(remainder * num_bits as usize);
+        let compressed_remainder_size = ceil8(remainder * num_bits);
         iterator
             .by_ref()
             .take(remainder)

--- a/src/page/mod.rs
+++ b/src/page/mod.rs
@@ -109,6 +109,10 @@ impl CompressedDataPage {
                 .map(|x| deserialize_statistics(x, self.descriptor.primitive_type.clone())),
         }
     }
+
+    pub fn set_selected_rows(&mut self, selected_rows: Vec<Interval>) {
+        self.selected_rows = Some(selected_rows);
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/read/compression.rs
+++ b/src/read/compression.rs
@@ -36,7 +36,7 @@ fn decompress_v2(
             ));
         }
 
-        (&mut buffer[..offset]).copy_from_slice(&compressed[..offset]);
+        buffer[..offset].copy_from_slice(&compressed[..offset]);
 
         compression::decompress(compression, &compressed[offset..], &mut buffer[offset..])?;
     } else {

--- a/src/read/metadata.rs
+++ b/src/read/metadata.rs
@@ -77,7 +77,7 @@ pub fn read_metadata<R: Read + Seek>(reader: &mut R) -> Result<FileMetaData> {
 
         buffer.clear();
         buffer.try_reserve(footer_len as usize)?;
-        reader.take(footer_len as u64).read_to_end(&mut buffer)?;
+        reader.take(footer_len).read_to_end(&mut buffer)?;
 
         &buffer
     };

--- a/src/read/page/mod.rs
+++ b/src/read/page/mod.rs
@@ -6,7 +6,7 @@ mod stream;
 use crate::{error::Error, page::CompressedPage};
 
 pub use indexed_reader::IndexedPageReader;
-pub use reader::{PageFilter, PageMetaData, PageReader};
+pub use reader::{PageFilter, PageInspector, PageMetaData, PageReader};
 
 pub trait PageIterator: Iterator<Item = Result<CompressedPage, Error>> {
     fn swap_buffer(&mut self, buffer: &mut Vec<u8>);

--- a/src/statistics/fixed_len_binary.rs
+++ b/src/statistics/fixed_len_binary.rs
@@ -56,11 +56,11 @@ pub fn read(
         null_count: v.null_count,
         distinct_count: v.distinct_count,
         max_value: v.max_value.clone().map(|mut x| {
-            x.truncate(size as usize);
+            x.truncate(size);
             x
         }),
         min_value: v.min_value.clone().map(|mut x| {
-            x.truncate(size as usize);
+            x.truncate(size);
             x
         }),
     }))

--- a/src/write/file.rs
+++ b/src/write/file.rs
@@ -125,7 +125,7 @@ impl<W: Write> FileWriter<W> {
     /// Returns an error if data has been written to the file.
     fn start(&mut self) -> Result<()> {
         if self.offset == 0 {
-            self.offset = start_file(&mut self.writer)? as u64;
+            self.offset = start_file(&mut self.writer)?;
             self.state = State::Started;
             Ok(())
         } else {

--- a/src/write/page.rs
+++ b/src/write/page.rs
@@ -65,7 +65,7 @@ pub fn write_page<W: Write>(
     }?;
 
     let header_size = write_page_header(writer, &header)?;
-    let mut bytes_written = header_size as u64;
+    let mut bytes_written = header_size;
 
     bytes_written += match &compressed_page {
         CompressedPage::Data(compressed_page) => {

--- a/tests/it/read/mod.rs
+++ b/tests/it/read/mod.rs
@@ -234,6 +234,7 @@ pub fn read_column<R: std::io::Read + std::io::Seek>(
         row_group,
         field,
         None,
+        None,
         vec![],
         usize::MAX,
     );


### PR DESCRIPTION
If there is a `PageInspector`, we can inspect the page information during page iteration in the runtime.

Besides, it's useful to allow user to change page's `selected_rows`. This let us be able to select rows of one page in the runtime (We can only pre-compute the `selected_rows` at once now).