### PR TITLE
Enbaled setting `selected_rows` in the runtime.

### DIFF
--- a/src/page/mod.rs
+++ b/src/page/mod.rs
@@ -109,6 +109,11 @@ impl CompressedDataPage {
                 .map(|x| deserialize_statistics(x, self.descriptor.primitive_type.clone())),
         }
     }
+
+    #[inline]
+    pub fn select_rows(&mut self, selected_rows: Vec<Interval>) {
+        self.selected_rows = Some(selected_rows);
+    }
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
It's useful to let user change the `selected_rows` during iteration.

For example:

```rust
// Prefetch one column and apply predicates to it to get a bitmap.
let bitmap = pre_fetch_and_filter(pre);
let bitmap = Arc::new(Mutex::new(bitmap));
// Use this bitmap to iterate the remaining column(s) and select rows;
let pages = PageReader::new_with_page_meta(
        reader,
        reader_meta,
        pages_filter,
        scratch,
        max_header_size,
    )
    .map(move |page| {
        page.map(|page| {
            page.select_rows(use_bitmap(bitmap));
        })
    });

let array_iter = column_iter_to_arrays(pages, ...);
// ...

```