### PR TITLE
Removed unnecessary flushes while writing

### DIFF
--- a/src/write/column_chunk.rs
+++ b/src/write/column_chunk.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 use std::io::Write;
 
-use parquet_format_safe::thrift::protocol::{TCompactOutputProtocol, TOutputProtocol};
+use parquet_format_safe::thrift::protocol::TCompactOutputProtocol;
 use parquet_format_safe::{ColumnChunk, ColumnMetaData, Type};
 
 #[cfg(feature = "async")]
@@ -58,7 +58,6 @@ where
         .as_ref()
         .unwrap()
         .write_to_out_protocol(&mut protocol)? as u64;
-    protocol.flush()?;
 
     Ok((column_chunk, specs, bytes_written))
 }
@@ -96,7 +95,6 @@ where
         .unwrap()
         .write_to_out_stream_protocol(&mut protocol)
         .await? as u64;
-    protocol.flush().await?;
 
     Ok((column_chunk, specs, bytes_written))
 }

--- a/src/write/file.rs
+++ b/src/write/file.rs
@@ -1,7 +1,6 @@
 use std::io::Write;
 
 use parquet_format_safe::thrift::protocol::TCompactOutputProtocol;
-use parquet_format_safe::thrift::protocol::TOutputProtocol;
 use parquet_format_safe::RowGroup;
 
 use crate::metadata::ThriftFileMetaData;
@@ -27,7 +26,6 @@ pub(super) fn end_file<W: Write>(mut writer: &mut W, metadata: &ThriftFileMetaDa
     // Write metadata
     let mut protocol = TCompactOutputProtocol::new(&mut writer);
     let metadata_len = metadata.write_to_out_protocol(&mut protocol)? as i32;
-    protocol.flush()?;
 
     // Write footer
     let metadata_bytes = metadata_len.to_le_bytes();
@@ -38,6 +36,7 @@ pub(super) fn end_file<W: Write>(mut writer: &mut W, metadata: &ThriftFileMetaDa
 
     (&mut footer_buffer[4..]).write_all(&PARQUET_MAGIC)?;
     writer.write_all(&footer_buffer)?;
+    writer.flush()?;
     Ok(metadata_len as u64 + FOOTER_SIZE)
 }
 

--- a/src/write/stream.rs
+++ b/src/write/stream.rs
@@ -30,7 +30,6 @@ async fn end_file<W: AsyncWrite + Unpin + Send>(
     // Write file metadata
     let mut protocol = TCompactOutputStreamProtocol::new(&mut writer);
     let metadata_len = metadata.write_to_out_stream_protocol(&mut protocol).await? as i32;
-    protocol.flush().await?;
 
     // Write footer
     let metadata_bytes = metadata_len.to_le_bytes();


### PR DESCRIPTION
As per: https://github.com/jorgecarleitao/parquet2/issues/199

Only two places where this would be a problem, sync and async version of the same method. TCompactOutputProtocol writes to the inner writer, which might or not might not be a buffered writer. Either way, performs better!

There are additional places where flushes are performed, specifically after writing the footer, but I could not see a good reason to remove that. Posssibly if you were sending multiple files over some type of transport where you wanted to optimize things? But even then, you would have to have quite small files for this to even remotely matter. Either way, I did note that this flush was only performed on the async implementation, so I added it to the sync version as well for consistencies sake.