### PR TITLE
feat:add read_metadata_with_size to reduce seek when size is known.

### DIFF
--- a/src/read/metadata.rs
+++ b/src/read/metadata.rs
@@ -35,6 +35,11 @@ fn stream_len(seek: &mut impl Seek) -> std::result::Result<u64, std::io::Error> 
 pub fn read_metadata<R: Read + Seek>(reader: &mut R) -> Result<FileMetaData> {
     // check file is large enough to hold footer
     let file_size = stream_len(reader)?;
+    read_metadata_with_size(reader, file_size)
+}
+
+/// Reads a [`FileMetaData`] from the reader, located at the end of the file, with known file size.
+pub fn read_metadata_with_size<R: Read + Seek>(reader: &mut R, file_size: u64) -> Result<FileMetaData> {
     if file_size < HEADER_SIZE + FOOTER_SIZE {
         return Err(Error::oos(
             "A parquet file must containt a header and footer with at least 12 bytes",

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 
 pub use column::*;
 pub use compression::{decompress, BasicDecompressor, Decompressor};
-pub use metadata::{deserialize_metadata, read_metadata};
+pub use metadata::{deserialize_metadata, read_metadata, read_metadata_with_size};
 #[cfg(feature = "async")]
 #[cfg_attr(docsrs, doc(cfg(feature = "async")))]
 pub use page::{get_page_stream, get_page_stream_from_column_start};


### PR DESCRIPTION
sometimes we collect infos of files before reading them,  the info may already include the file size.