### PR TITLE
fix check decimal scale equal to precision

### DIFF
--- a/src/read/metadata.rs
+++ b/src/read/metadata.rs
@@ -39,7 +39,10 @@ pub fn read_metadata<R: Read + Seek>(reader: &mut R) -> Result<FileMetaData> {
 }
 
 /// Reads a [`FileMetaData`] from the reader, located at the end of the file, with known file size.
-pub fn read_metadata_with_size<R: Read + Seek>(reader: &mut R, file_size: u64) -> Result<FileMetaData> {
+pub fn read_metadata_with_size<R: Read + Seek>(
+    reader: &mut R,
+    file_size: u64,
+) -> Result<FileMetaData> {
     if file_size < HEADER_SIZE + FOOTER_SIZE {
         return Err(Error::oos(
             "A parquet file must containt a header and footer with at least 12 bytes",

--- a/src/schema/types/spec.rs
+++ b/src/schema/types/spec.rs
@@ -14,9 +14,9 @@ fn check_decimal_invariants(
             precision,
         )));
     }
-    if scale >= precision {
+    if scale > precision {
         return Err(Error::oos(format!(
-            "Invalid DECIMAL: scale ({}) cannot be greater than or equal to precision \
+            "Invalid DECIMAL: scale ({}) cannot be greater than precision \
             ({})",
             scale, precision
         )));


### PR DESCRIPTION
fix decimal values can not be inserted when scale is equal to precision.
According to [parquet format](https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#decimal), Scale must be zero or a positive integer less than or equal to the precision.