### PR TITLE
chore: bump brotli dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ async-stream = { version = "0.3.3", optional = true }
 futures = { version = "0.3", optional = true }
 
 snap = { version = "^1.1", optional = true }
-brotli = { version = "^3.3", optional = true }
+brotli = { version = "^6.0", optional = true }
 flate2 = { version = "^1.0", optional = true, default-features = false }
 lz4 = { version = "1.24", optional = true }
 zstd = { version = "^0.12", optional = true, default-features = false }


### PR DESCRIPTION
brotli v6 plays nice with other versions of the same crate